### PR TITLE
Fix master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # goose
-goose (Go OpenStack Exchange) - Go bindings for talking to OpenStack.
+Go OpenStack Exchange - Go bindings for talking to OpenStack.
 
-**NOTE**: Work in progress - in the process of migrating existing code from https://launchpad.net/goose.
+The `master` branch is just a placeholder, please use branch [`v1`](https://github.com/go-goose/goose/tree/v1) or later.
+

--- a/error.go
+++ b/error.go
@@ -1,0 +1,5 @@
+package error
+
+func error() {
+	`ERROR: the correct import path is gopkg.in/goose.v1 ... `
+}


### PR DESCRIPTION
Describe the purpose of "master" as a placeholder branch, and add an error.go like mgo has.
