### PR TITLE
nova: add Metadata to RunServerOpts

### DIFF
--- a/nova/nova.go
+++ b/nova/nova.go
@@ -222,13 +222,14 @@ type ServerDetail struct {
 	// in RFC3339 format.
 	Created string
 
-	Flavor Entity
-	HostId string
-	Id     string `json:"-"`
-	UUID   string
-	Image  Entity
-	Links  []Link
-	Name   string
+	Flavor   Entity
+	HostId   string
+	Id       string `json:"-"`
+	UUID     string
+	Image    Entity
+	Links    []Link
+	Name     string
+	Metadata map[string]string
 
 	// HP Cloud returns security groups in server details.
 	Groups []Entity `json:"security_groups"`
@@ -319,6 +320,7 @@ type RunServerOpts struct {
 	SecurityGroupNames []SecurityGroupName `json:"security_groups"`             // Optional
 	Networks           []ServerNetworks    `json:"networks"`                    // Optional
 	AvailabilityZone   string              `json:"availability_zone,omitempty"` // Optional
+	Metadata           map[string]string   `json:"metadata,omitempty"`          // Optional
 }
 
 // RunServer creates a new server, based on the given RunServerOpts.

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -611,6 +611,7 @@ func (n *Nova) handleRunServer(body []byte, w http.ResponseWriter, r *http.Reque
 		Updated:          timestr,
 		Addresses:        make(map[string][]nova.IPAddress),
 		AvailabilityZone: req.Server.AvailabilityZone,
+		Metadata:         req.Server.Metadata,
 	}
 	servers, err := n.allServers(nil)
 	if err != nil {


### PR DESCRIPTION
This commit adds the Metadata field to
RunServerOpts, and updates the test server
to extract the parameter and add it to
server details.
