### PR TITLE
nova: implement POST /servers/<id>/metadata

### DIFF
--- a/nova/nova.go
+++ b/nova/nova.go
@@ -790,3 +790,20 @@ func (c *Client) ListVolumeAttachments(serverId string) ([]VolumeAttachment, err
 	}
 	return resp.VolumeAttachments, nil
 }
+
+// SetServerMetadata sets metadata on a server.
+func (c *Client) SetServerMetadata(serverId string, metadata map[string]string) error {
+	req := struct {
+		Metadata map[string]string `json:"metadata"`
+	}{metadata}
+
+	url := fmt.Sprintf("%s/%s/metadata", apiServers, serverId)
+	requestData := goosehttp.RequestData{
+		ReqValue: req, ExpectedStatus: []int{http.StatusOK},
+	}
+	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	if err != nil {
+		err = errors.Newf(err, "failed to set metadata %v on server with id: %s", metadata, serverId)
+	}
+	return err
+}

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -849,3 +849,22 @@ func (a azByName) Less(i, j int) bool {
 func (a azByName) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
+
+// setServerMetadata sets metadata on a server.
+func (n *Nova) setServerMetadata(serverId string, metadata map[string]string) error {
+	if err := n.ProcessFunctionHook(n, serverId, metadata); err != nil {
+		return err
+	}
+	server, err := n.server(serverId)
+	if err != nil {
+		return err
+	}
+	if server.Metadata == nil {
+		server.Metadata = make(map[string]string)
+	}
+	for k, v := range metadata {
+		server.Metadata[k] = v
+	}
+	n.servers[serverId] = *server
+	return nil
+}

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -1271,3 +1271,25 @@ func (s *NovaHTTPSSuite) TestHasHTTPSServiceURL(c *gc.C) {
 	endpoints := s.service.Endpoints()
 	c.Assert(endpoints[0].PublicURL[:8], gc.Equals, "https://")
 }
+
+func (s *NovaHTTPSuite) TestSetServerMetadata(c *gc.C) {
+	const serverId = "sr1"
+
+	err := s.service.addServer(nova.ServerDetail{Id: serverId})
+	c.Assert(err, gc.IsNil)
+	defer s.service.removeServer(serverId)
+	var req struct {
+		Metadata map[string]string `json:"metadata"`
+	}
+	req.Metadata = map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}
+	resp, err := s.jsonRequest("POST", "/servers/"+serverId+"/metadata", req, nil)
+	c.Assert(err, gc.IsNil)
+	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
+
+	server, err := s.service.server(serverId)
+	c.Assert(err, gc.IsNil)
+	c.Assert(server.Metadata, gc.DeepEquals, req.Metadata)
+}


### PR DESCRIPTION
Support POSTing to /servers/<id>/metadata to
update server metadata. This will be used by
Juju to upgrade existing environments away
from relying on Swift for storing server
metadata.
