### PR TITLE
cinder: correct type for Volume.Metadata

### DIFF
--- a/cinder/autogenerated_client.go
+++ b/cinder/autogenerated_client.go
@@ -423,17 +423,15 @@ type Volume struct {
 		Href string `json:"href"`
 		Rel  string `json:"rel"`
 	} `json:"links"`
-	Metadata struct {
-		Contents string `json:"contents"`
-	} `json:"metadata"`
-	Name                        string      `json:"name"`
-	Os_Vol_Host_Attr_Host       string      `json:"os-vol-host-attr:host"`
-	Os_Vol_Tenant_Attr_TenantID string      `json:"os-vol-tenant-attr:tenant_id"`
-	Size                        int         `json:"size"`
-	SnapshotID                  interface{} `json:"snapshot_id"`
-	SourceVolid                 interface{} `json:"source_volid"`
-	Status                      string      `json:"status"`
-	VolumeType                  string      `json:"volume_type"`
+	Metadata                    map[string]string `json:"metadata"`
+	Name                        string            `json:"name"`
+	Os_Vol_Host_Attr_Host       string            `json:"os-vol-host-attr:host"`
+	Os_Vol_Tenant_Attr_TenantID string            `json:"os-vol-tenant-attr:tenant_id"`
+	Size                        int               `json:"size"`
+	SnapshotID                  interface{}       `json:"snapshot_id"`
+	SourceVolid                 interface{}       `json:"source_volid"`
+	Status                      string            `json:"status"`
+	VolumeType                  string            `json:"volume_type"`
 }
 
 type GetVolumesDetailResults struct {

--- a/cinder/client.go
+++ b/cinder/client.go
@@ -273,7 +273,10 @@ func notifier(predicate predicateFn, numAttempts int, waitDur time.Duration) <-c
 func (c *Client) VolumeStatusNotifier(volId, status string, numAttempts int, waitDur time.Duration) <-chan error {
 	statusMatches := func() (bool, error) {
 		volInfo, err := c.GetVolume(volId)
-		return volInfo.Volume.Status == status, err
+		if err != nil {
+			return false, err
+		}
+		return volInfo.Volume.Status == status, nil
 	}
 	return notifier(statusMatches, numAttempts, waitDur)
 }
@@ -285,7 +288,10 @@ func (c *Client) VolumeStatusNotifier(volId, status string, numAttempts int, wai
 func (c *Client) SnapshotStatusNotifier(snapId, status string, numAttempts int, waitDur time.Duration) <-chan error {
 	statusMatches := func() (bool, error) {
 		snapInfo, err := c.GetSnapshot(snapId)
-		return snapInfo.Snapshot.Status == status, err
+		if err != nil {
+			return false, err
+		}
+		return snapInfo.Snapshot.Status == status, nil
 	}
 	return notifier(statusMatches, numAttempts, waitDur)
 }

--- a/cinder/live_test.go
+++ b/cinder/live_test.go
@@ -107,3 +107,25 @@ func (s *liveCinderSuite) TestVolumeTypeOperations(c *gc.C) {
 	err = s.client.DeleteVolumeType(typeInfo.VolumeType.ID)
 	c.Assert(err, gc.IsNil)
 }
+
+func (s *liveCinderSuite) TestVolumeMetadata(c *gc.C) {
+
+	metadata := map[string]string{
+		"a": "b",
+		"c": "d",
+	}
+	volInfo, err := s.client.CreateVolume(CreateVolumeVolumeParams{
+		Size:     1,
+		Metadata: metadata,
+	})
+	c.Assert(err, gc.IsNil)
+	defer func() {
+		err := s.client.DeleteVolume(volInfo.Volume.ID)
+		c.Assert(err, gc.IsNil)
+	}()
+
+	result, err := s.client.GetVolume(volInfo.Volume.ID)
+	c.Assert(err, gc.IsNil)
+	c.Assert(result, gc.NotNil)
+	c.Assert(result.Volume.Metadata, gc.DeepEquals, metadata)
+}


### PR DESCRIPTION
Fix the type of Volume.Metadata. The type was wrongly deduced by wadl2go.

Also, a couple of drive-by fixes found when running live tests.
