### PR TITLE
nova, cinder: volume attachments fixes

### DIFF
--- a/cinder/autogenerated_client.go
+++ b/cinder/autogenerated_client.go
@@ -412,13 +412,20 @@ type GetVolumesDetailParams struct {
 	TenantId string `json:"-"`
 }
 
+type VolumeAttachment struct {
+	Device   string `json:"device"`
+	Id       string `json:"id"`
+	ServerId string `json:"server_id"`
+	VolumeId string `json:"volume_id"`
+}
+
 type Volume struct {
-	Attachments      []interface{} `json:"attachments"`
-	AvailabilityZone string        `json:"availability_zone"`
-	Bootable         string        `json:"bootable"`
-	CreatedAt        string        `json:"created_at"`
-	Description      string        `json:"description"`
-	ID               string        `json:"id"`
+	Attachments      []VolumeAttachment `json:"attachments"`
+	AvailabilityZone string             `json:"availability_zone"`
+	Bootable         string             `json:"bootable"`
+	CreatedAt        string             `json:"created_at"`
+	Description      string             `json:"description"`
+	ID               string             `json:"id"`
 	Links            []struct {
 		Href string `json:"href"`
 		Rel  string `json:"rel"`

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -755,7 +755,9 @@ func (c *Client) AttachVolume(serverId, volumeId, device string) (*VolumeAttachm
 // DetachVolume detaches the volume with the given attachmentId from
 // the server with the given serverId.
 func (c *Client) DetachVolume(serverId, attachmentId string) error {
-	requestData := goosehttp.RequestData{}
+	requestData := goosehttp.RequestData{
+		ExpectedStatus: []int{http.StatusAccepted},
+	}
 	url := fmt.Sprintf("%s/%s/%s/%s", apiServers, serverId, apiVolumeAttachments, attachmentId)
 	err := c.client.SendRequest(client.DELETE, "compute", url, &requestData)
 	if errors.IsNotFound(err) {

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -1139,6 +1139,7 @@ func (n *Nova) handleDetachVolumes(w http.ResponseWriter, r *http.Request) error
 		if vol.Id == attachId {
 			serverVols = append(serverVols[:volIdx], serverVols[volIdx+1:]...)
 			n.serverIdToAttachedVolumes[serverId] = serverVols
+			writeResponse(w, http.StatusAccepted, nil)
 			return nil
 		}
 	}


### PR DESCRIPTION
Two fixes:
- cinder.Volume.Attachments should have a slice-of-struct
  type, not []interface{}. This is done now. The JSON
  schema has been verified with live data.
- nova.Client.DetachVolume should expect 202 from the
  server upon successful detach. This is according to
  the docs, and to reality (found a bug testing Juju).
