### PR TITLE
add update for secgroup and server

### DIFF
--- a/nova/live_test.go
+++ b/nova/live_test.go
@@ -567,6 +567,26 @@ func (s *LiveTests) TestRunServerUnknownAvailabilityZone(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*The requested availability zone is not available(.|\n)*")
 }
 
+func (s *LiveTests) TestUpdateServerName(c *gc.C) {
+	entity, err := s.nova.RunServer(nova.RunServerOpts{
+		Name:             "oldName",
+		FlavorId:         s.testFlavorId,
+		ImageId:          s.testImageId,
+		AvailabilityZone: s.testAvailabilityZone,
+		Metadata:         map[string]string{},
+	})
+	c.Assert(err, gc.IsNil)
+	defer s.nova.DeleteServer(entity.Id)
+
+	newEntity, err := s.nova.UpdateServerName(entity.Id, "newName")
+	c.Assert(err, gc.IsNil)
+	c.Assert(newEntity.Name, gc.Equals, "newName")
+
+	server, err := s.nova.GetServer(entity.Id)
+	c.Assert(err, gc.IsNil)
+	c.Assert(server.Name, gc.Equals, "newName")
+}
+
 func (s *LiveTests) TestInstanceMetadata(c *gc.C) {
 	metadata := map[string]string{"my-key": "my-value"}
 	entity, err := s.nova.RunServer(nova.RunServerOpts{

--- a/nova/live_test.go
+++ b/nova/live_test.go
@@ -286,6 +286,35 @@ func (s *LiveTests) TestCreateAndDeleteSecurityGroup(c *gc.C) {
 	}
 }
 
+func (s *LiveTests) TestUpdateSecurityGroup(c *gc.C) {
+	group, err := s.nova.CreateSecurityGroup("test_secgroup", "test_desc")
+	c.Assert(err, gc.IsNil)
+	c.Check(group.Name, gc.Equals, "test_secgroup")
+	c.Check(group.Description, gc.Equals, "test_desc")
+
+	groupUpdated, err := s.nova.UpdateSecurityGroup(group.Id, "test_secgroup_new", "test_desc_new")
+	c.Assert(err, gc.IsNil)
+	c.Check(groupUpdated.Name, gc.Equals, "test_secgroup_new")
+	c.Check(groupUpdated.Description, gc.Equals, "test_desc_new")
+
+	groups, err := s.nova.ListSecurityGroups()
+	found := false
+	for _, g := range groups {
+		if g.Id == group.Id {
+			found = true
+			c.Assert(g.Name, gc.Equals, "test_secgroup_new")
+			c.Assert(g.Description, gc.Equals, "test_desc_new")
+			break
+		}
+	}
+	if found {
+		err = s.nova.DeleteSecurityGroup(group.Id)
+		c.Check(err, gc.IsNil)
+	} else {
+		c.Fatalf("test security group (%d) not found", group.Id)
+	}
+}
+
 func (s *LiveTests) TestDuplicateSecurityGroupError(c *gc.C) {
 	group, err := s.nova.CreateSecurityGroup("test_dupgroup", "test_desc")
 	c.Assert(err, gc.IsNil)

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -342,6 +342,28 @@ func (c *Client) RunServer(opts RunServerOpts) (*Entity, error) {
 	return &resp.Server, nil
 }
 
+type serverUpdateNameOpts struct {
+	Name string `json:"name"`
+}
+
+// UpdateServerName updates the name of the given server.
+func (c *Client) UpdateServerName(serverID, name string) (*Entity, error) {
+	var req struct {
+		Server serverUpdateNameOpts `json:"server"`
+	}
+	var resp struct {
+		Server Entity `json:"server"`
+	}
+	req.Server = serverUpdateNameOpts{Name: name}
+	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp, ExpectedStatus: []int{http.StatusOK}}
+	url := fmt.Sprintf("%s/%s", apiServers, serverID)
+	err := c.client.SendRequest(client.PUT, "compute", url, &requestData)
+	if err != nil {
+		return nil, errors.Newf(err, "failed to update server name to %q", name)
+	}
+	return &resp.Server, nil
+}
+
 // SecurityGroupRef refers to an existing named security group
 type SecurityGroupRef struct {
 	TenantId string `json:"tenant_id"`

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -462,6 +462,28 @@ func (c *Client) DeleteSecurityGroup(groupId string) error {
 	return err
 }
 
+// UpdateSecurityGroup updates the name and description of the given group.
+func (c *Client) UpdateSecurityGroup(groupId, name, description string) (*SecurityGroup, error) {
+	var req struct {
+		SecurityGroup struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"security_group"`
+	}
+	req.SecurityGroup.Name = name
+	req.SecurityGroup.Description = description
+	var resp struct {
+		SecurityGroup SecurityGroup `json:"security_group"`
+	}
+	url := fmt.Sprintf("%s/%s", apiSecurityGroups, groupId)
+	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp, ExpectedStatus: []int{http.StatusOK}}
+	err := c.client.SendRequest(client.PUT, "compute", url, &requestData)
+	if err != nil {
+		return nil, errors.Newf(err, "failed to update security group with Id %s to name: %s", groupId, name)
+	}
+	return &resp.SecurityGroup, nil
+}
+
 // RuleInfo allows the callers of CreateSecurityGroupRule() to
 // create 2 types of security group rules: ingress rules and group
 // rules. The difference stems from how the "source" is defined.

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -406,6 +406,20 @@ func (n *Nova) removeServer(serverId string) error {
 	return nil
 }
 
+func (n *Nova) updateSecurityGroup(group nova.SecurityGroup) error {
+	if err := n.ProcessFunctionHook(n, group); err != nil {
+		return err
+	}
+	existingGroup, err := n.securityGroup(group.Id)
+	if err != nil {
+		return testservices.NewSecurityGroupByIDNotFoundError(group.Id)
+	}
+	existingGroup.Name = group.Name
+	existingGroup.Description = group.Description
+	n.groups[group.Id] = *existingGroup
+	return nil
+}
+
 // addSecurityGroup creates a new security group.
 func (n *Nova) addSecurityGroup(group nova.SecurityGroup) error {
 	if err := n.ProcessFunctionHook(n, group); err != nil {

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -260,6 +260,20 @@ func (n *Nova) addServer(server nova.ServerDetail) error {
 	return nil
 }
 
+// updateServerName creates a new server.
+func (n *Nova) updateServerName(serverId, name string) error {
+	if err := n.ProcessFunctionHook(n, serverId); err != nil {
+		return err
+	}
+	server, err := n.server(serverId)
+	if err != nil {
+		return testservices.NewServerByIDNotFoundError(serverId)
+	}
+	server.Name = name
+	n.servers[serverId] = *server
+	return nil
+}
+
 // server retrieves an existing server by ID.
 func (n *Nova) server(serverId string) (*nova.ServerDetail, error) {
 	if err := n.ProcessFunctionHook(n, serverId); err != nil {

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -905,10 +905,47 @@ func (n *Nova) handleSecurityGroups(w http.ResponseWriter, r *http.Request) erro
 			return sendJSON(http.StatusOK, resp, w, r)
 		}
 	case "PUT":
-		if groupId := path.Base(r.URL.Path); groupId != "os-security-groups" {
-			return errNotFoundJSON
+		if groupId := path.Base(r.URL.Path); groupId == "os-security-groups" {
+			return errNotFound
 		}
-		return errNotFound
+		group, err := n.processGroupId(w, r)
+		if err != nil {
+			return err
+		}
+
+		var req struct {
+			Group struct {
+				Name        string
+				Description string
+			} `json:"security_group"`
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil || len(body) == 0 {
+			return errBadRequest2
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return err
+		}
+
+		err = n.updateSecurityGroup(nova.SecurityGroup{
+			Id:          group.Id,
+			Name:        req.Group.Name,
+			Description: req.Group.Description,
+			TenantId:    group.TenantId,
+		})
+		if err != nil {
+			return err
+		}
+		group, err = n.securityGroup(group.Id)
+		if err != nil {
+			return err
+		}
+		var resp struct {
+			Group nova.SecurityGroup `json:"security_group"`
+		}
+		resp.Group = *group
+		return sendJSON(http.StatusOK, resp, w, r)
+
 	case "DELETE":
 		if group, err := n.processGroupId(w, r); group != nil {
 			if err := n.removeSecurityGroup(group.Id); err != nil {

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -354,7 +354,7 @@ func (s *NovaHTTPSuite) simpleTests() []SimpleTest {
 		{
 			method: "PUT",
 			url:    "/os-security-groups/invalid",
-			expect: errNotFoundJSON,
+			expect: errNotFoundJSONSG,
 		},
 		{
 			method: "DELETE",


### PR DESCRIPTION
- Support updating of name and description for security groups as
  described in the Openstack API
  http://developer.openstack.org/api-ref-networking-v2-ext.html#updateSecGrou
- Added the capability to update server name as per the API available
  for openstack compute (there are two different update possibilities,
  the only one implemented is the one that supports name only)
  http://developer.openstack.org/api-ref-compute-v2.html#updateServer
