### PR TITLE
Added VirtType to FlavourDetail to support multi-hypervisor.

### DIFF
--- a/nova/json_test.go
+++ b/nova/json_test.go
@@ -40,6 +40,12 @@ func (s *JsonSuite) TestMarshallFlavorDetailLargeIntId(c *gc.C) {
 	s.assertMarshallRoundtrip(c, &fd, &unmarshalled)
 }
 
+func (s *JsonSuite) TestMarshallFlavorDetailVirtType(c *gc.C) {
+	fd := nova.FlavorDetail{Id: "20", Name: "test", VirtType: "kvm"}
+	var unmarshalled nova.FlavorDetail
+	s.assertMarshallRoundtrip(c, &fd, &unmarshalled)
+}
+
 func (s *JsonSuite) TestMarshallServerDetailLargeIntId(c *gc.C) {
 	fd := nova.Entity{Id: "2000000", Name: "test"}
 	im := nova.Entity{Id: "2000000", Name: "test"}

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -143,12 +143,13 @@ func (c *Client) ListFlavors() ([]Entity, error) {
 
 // FlavorDetail describes detailed information about a flavor.
 type FlavorDetail struct {
-	Name  string
-	RAM   int    // Available RAM, in MB
-	VCPUs int    // Number of virtual CPU (cores)
-	Disk  int    // Available root partition space, in GB
-	Id    string `json:"-"`
-	Links []Link
+	Name     string
+	RAM      int    // Available RAM, in MB
+	VCPUs    int    // Number of virtual CPU (cores)
+	Disk     int    // Available root partition space, in GB
+	Id       string `json:"-"`
+	Links    []Link
+	VirtType string // Virtual type to support multi-hypervisor
 }
 
 // Allow FlavorDetail slices to be sorted by named attribute.

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -90,6 +90,7 @@ func New(hostURL, versionPath, tenantId, region string, identityService identity
 		{Id: "1", Name: "m1.tiny", RAM: 512, VCPUs: 1},
 		{Id: "2", Name: "m1.small", RAM: 2048, VCPUs: 1},
 		{Id: "3", Name: "m1.medium", RAM: 4096, VCPUs: 2},
+		{Id: "4", Name: "cc1.4xlarge", RAM: 4096, VCPUs: 2, VirtType: "kvm"},
 	}
 	// Real openstack instances have a default security group "out of the box". So we add it here.
 	defaultSecurityGroups := []nova.SecurityGroup{

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -478,9 +478,9 @@ func (s *NovaHTTPSuite) TestGetFlavors(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	assertJSON(c, resp, &expected)
-	c.Assert(expected.Flavors, gc.HasLen, 3)
+	c.Assert(expected.Flavors, gc.HasLen, 4)
 	entities := s.service.allFlavorsAsEntities()
-	c.Assert(entities, gc.HasLen, 3)
+	c.Assert(entities, gc.HasLen, 4)
 	sort.Sort(nova.EntitySortBy{Attr: "Id", Entities: expected.Flavors})
 	sort.Sort(nova.EntitySortBy{Attr: "Id", Entities: entities})
 	c.Assert(expected.Flavors, gc.DeepEquals, entities)
@@ -497,7 +497,7 @@ func (s *NovaHTTPSuite) TestGetFlavors(c *gc.C) {
 func (s *NovaHTTPSuite) TestGetFlavorsDetail(c *gc.C) {
 	// The test service has 3 default flavours.
 	flavors := s.service.allFlavors()
-	c.Assert(flavors, gc.HasLen, 3)
+	c.Assert(flavors, gc.HasLen, 4)
 	var expected struct {
 		Flavors []nova.FlavorDetail
 	}
@@ -505,7 +505,7 @@ func (s *NovaHTTPSuite) TestGetFlavorsDetail(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	assertJSON(c, resp, &expected)
-	c.Assert(expected.Flavors, gc.HasLen, 3)
+	c.Assert(expected.Flavors, gc.HasLen, 4)
 	sort.Sort(nova.FlavorDetailSortBy{Attr: "Id", FlavorDetails: expected.Flavors})
 	sort.Sort(nova.FlavorDetailSortBy{Attr: "Id", FlavorDetails: flavors})
 	c.Assert(expected.Flavors, gc.DeepEquals, flavors)

--- a/testservices/novaservice/service_test.go
+++ b/testservices/novaservice/service_test.go
@@ -158,18 +158,18 @@ func (s *NovaSuite) TestRemoveFlavorTwiceFails(c *gc.C) {
 func (s *NovaSuite) TestAllFlavors(c *gc.C) {
 	// The test service has 2 default flavours.
 	flavors := s.service.allFlavors()
-	c.Assert(flavors, gc.HasLen, 3)
+	c.Assert(flavors, gc.HasLen, 4)
 	for _, fl := range flavors {
-		c.Assert(fl.Name == "m1.tiny" || fl.Name == "m1.small" || fl.Name == "m1.medium", gc.Equals, true)
+		c.Assert(fl.Name == "m1.tiny" || fl.Name == "m1.small" || fl.Name == "m1.medium" || fl.Name == "cc1.4xlarge", gc.Equals, true)
 	}
 }
 
 func (s *NovaSuite) TestAllFlavorsAsEntities(c *gc.C) {
 	// The test service has 2 default flavours.
 	entities := s.service.allFlavorsAsEntities()
-	c.Assert(entities, gc.HasLen, 3)
+	c.Assert(entities, gc.HasLen, 4)
 	for _, fl := range entities {
-		c.Assert(fl.Name == "m1.tiny" || fl.Name == "m1.small" || fl.Name == "m1.medium", gc.Equals, true)
+		c.Assert(fl.Name == "m1.tiny" || fl.Name == "m1.small" || fl.Name == "m1.medium" || fl.Name == "cc1.4xlarge", gc.Equals, true)
 	}
 }
 


### PR DESCRIPTION
This is part of the fix for enabling multi-hypervisor in OpenStack clouds.

Related to https://bugs.launchpad.net/juju-core/+bug/1524297
