### PR TITLE
Update goose to find endpoints by requesting version information befo…

### DIFF
--- a/client/apiversion.go
+++ b/client/apiversion.go
@@ -1,0 +1,213 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	goosehttp "gopkg.in/goose.v1/http"
+)
+
+type apiVersion struct {
+	major int
+	minor int
+}
+
+type apiVersionInfo struct {
+	Version apiVersion       `json:"id"`
+	Links   []apiVersionLink `json:"links"`
+	Status  string           `json:"status"`
+}
+
+type apiVersionLink struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
+type apiURLVersion struct {
+	rootURL          url.URL
+	serviceURLSuffix string
+	versions         []apiVersionInfo
+}
+
+// getAPIVersionURL returns a full formed serviceURL based on the API version requested,
+// the rootURL and the serviceURLSuffix.  If there is no match to the requested API
+// version an error is returned.  If only the major number is defined for the requested
+// version, the first match found is returned.
+func getAPIVersionURL(apiURLVersionInfo *apiURLVersion, requested apiVersion) (string, error) {
+	var match string
+	for _, v := range apiURLVersionInfo.versions {
+		if v.Version.major != requested.major {
+			continue
+		}
+		if requested.minor != -1 && v.Version.minor != requested.minor {
+			continue
+		}
+		for _, link := range v.Links {
+			if link.Rel != "self" {
+				continue
+			}
+			hrefURL, err := url.Parse(link.Href)
+			if err != nil {
+				return "", err
+			}
+			match = hrefURL.Path
+		}
+		if requested.minor != -1 {
+			break
+		}
+	}
+	if match == "" {
+		return "", fmt.Errorf("could not find matching URL")
+	}
+	versionURL := apiURLVersionInfo.rootURL
+	versionURL.Path = path.Join(versionURL.Path, match, apiURLVersionInfo.serviceURLSuffix)
+	return versionURL.String(), nil
+}
+
+func (v *apiVersion) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	parsed, err := parseVersion(s)
+	if err != nil {
+		return err
+	}
+	*v = parsed
+	return nil
+}
+
+// parseVersion takes a version string into the major and minor ints for an apiVersion
+// structure. The string part of the data is returned by a request to List API versions
+// send to an OpenStack service.  It is in the format "v<major>.<minor>". If apiVersion
+// is empty, return {-1, -1}, to differentiate with "v0".
+func parseVersion(s string) (apiVersion, error) {
+	if s == "" {
+		return apiVersion{-1, -1}, nil
+	}
+	s = strings.TrimPrefix(s, "v")
+	parts := strings.SplitN(s, ".", 2)
+	if len(parts) == 0 || len(parts) > 2 {
+		return apiVersion{}, fmt.Errorf("invalid API version %q", s)
+	}
+	var minor int = -1
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return apiVersion{}, err
+	}
+	if len(parts) == 2 {
+		var err error
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return apiVersion{}, err
+		}
+	}
+	return apiVersion{major, minor}, nil
+}
+
+func unmarshallVersion(Versions json.RawMessage) ([]apiVersionInfo, error) {
+	// Some services respond with {"versions":[...]}, and
+	// some respond with {"versions":{"values":[...]}}.
+	var object interface{}
+	var versions []apiVersionInfo
+	if err := json.Unmarshal(Versions, &object); err != nil {
+		return versions, err
+	}
+	if _, ok := object.(map[string]interface{}); ok {
+		var valuesObject struct {
+			Values []apiVersionInfo `json:"values"`
+		}
+		if err := json.Unmarshal(Versions, &valuesObject); err != nil {
+			return versions, err
+		}
+		versions = valuesObject.Values
+	} else {
+		if err := json.Unmarshal(Versions, &versions); err != nil {
+			return versions, err
+		}
+	}
+	return versions, nil
+}
+
+// getAPIVersions returns data on the API versions supported by the specified service endpoint.
+func (c *authenticatingClient) getAPIVersions(serviceCatalogURL string) (*apiURLVersion, error) {
+	url, err := url.Parse(serviceCatalogURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Identify the version in the URL, if there is one, and record
+	// everything proceeding it. We will need to append this to the
+	// API version-specific base URL.
+	var pathParts, origPathParts []string
+	if url.Path != "/" {
+		// The rackspace object-store endpoint triggers the version removal here,
+		// so keep the original parts for object-store and container endpoints.
+		// e.g. https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_1019383
+		origPathParts = strings.Split(strings.Trim(url.Path, "/"), "/")
+		pathParts = origPathParts
+		if _, err := parseVersion(pathParts[0]); err == nil {
+			pathParts = pathParts[1:]
+		}
+		url.Path = "/"
+	}
+
+	baseURL := url.String()
+
+	// If this is an object-store serviceType, or an object-store container endpoint,
+	// there is no list version API call to make. Return a apiURLVersion which will
+	// satisfy a requested api version of "", "v1" or "v1.0"
+	if c.serviceURLs["object-store"] != "" && strings.Contains(serviceCatalogURL, c.serviceURLs["object-store"]) {
+		objectStoreLink := apiVersionLink{Href: baseURL, Rel: "self"}
+		objectStoreApiVersionInfo := []apiVersionInfo{
+			{
+				Version: apiVersion{major: 1, minor: 0},
+				Links:   []apiVersionLink{objectStoreLink},
+				Status:  "stable",
+			},
+			{
+				Version: apiVersion{major: -1, minor: -1},
+				Links:   []apiVersionLink{objectStoreLink},
+				Status:  "stable",
+			},
+		}
+		return &apiURLVersion{*url, strings.Join(origPathParts, "/"), objectStoreApiVersionInfo}, nil
+	}
+
+	// make sure we haven't already received the version info
+	c.apiVersionMu.Lock()
+	defer c.apiVersionMu.Unlock()
+	if apiInfo, ok := c.apiURLVersions[baseURL]; ok {
+		return apiInfo, nil
+	}
+
+	var raw struct {
+		Versions json.RawMessage `json:"versions"`
+	}
+	requestData := &goosehttp.RequestData{
+		RespValue: &raw,
+		ExpectedStatus: []int{
+			http.StatusOK,
+			http.StatusMultipleChoices,
+		},
+	}
+	if err := c.sendRequest("GET", baseURL, c.Token(), requestData); err != nil {
+		return nil, err
+	}
+
+	versions, err := unmarshallVersion(raw.Versions)
+	if err != nil {
+		return nil, err
+	}
+
+	// save this info, so we don't have to get it again
+	apiURLVersionInfo := &apiURLVersion{*url, strings.Join(pathParts, "/"), versions}
+	c.apiURLVersions[baseURL] = apiURLVersionInfo
+
+	return apiURLVersionInfo, nil
+}

--- a/client/apiversion_test.go
+++ b/client/apiversion_test.go
@@ -1,0 +1,191 @@
+package client_test
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	gc "gopkg.in/check.v1"
+)
+
+type versionHandler struct {
+	authBody string
+	port     string
+}
+
+type makeServiceURLTest struct {
+	serviceType string
+	version     string
+	parts       []string
+	success     bool
+	URL         string
+	err         string
+}
+
+func (s *localLiveSuite) makeServiceURLTests() []makeServiceURLTest {
+	return []makeServiceURLTest{
+		{
+			serviceType: "compute",
+			version:     "v2.1",
+			parts:       []string{"foo", "bar/"},
+			success:     true,
+			URL:         "http://localhost:%s/v2.1/foo/bar/",
+		},
+		{
+			serviceType: "compute",
+			version:     "v2.0",
+			parts:       []string{},
+			success:     true,
+			URL:         "http://localhost:%s/v2.0",
+		},
+		{
+			serviceType: "compute",
+			version:     "v2.0",
+			parts:       []string{"foo", "bar/"},
+			success:     true,
+			URL:         "http://localhost:%s/v2.0/foo/bar/",
+		},
+		{
+			serviceType: "compute",
+			version:     "v2",
+			parts:       []string{"foo", "bar/"},
+			success:     true,
+			URL:         "http://localhost:%s/v2.1/foo/bar/",
+		},
+		{
+			serviceType: "object-store",
+			version:     "",
+			parts:       []string{"foo", "bar"},
+			success:     true,
+			URL:         "http://localhost:%s/swift/v1/foo/bar",
+		},
+		{
+			serviceType: "object-store",
+			version:     "q2.0",
+			parts:       []string{"foo", "bar/"},
+			success:     false,
+			err:         "strconv.ParseInt: parsing \"q2\": invalid syntax",
+		},
+		{
+			serviceType: "object-store",
+			version:     "v1.7",
+			parts:       []string{"foo", "bar/"},
+			success:     false,
+			err:         "could not find matching URL",
+		},
+		{
+			serviceType: "juju-container-test",
+			version:     "v1",
+			parts:       []string{"foo", "bar/"},
+			success:     true,
+			URL:         "http://localhost:%s/swift/v1/foo/bar/",
+		},
+		{
+			serviceType: "juju-container-test",
+			version:     "v0",
+			parts:       []string{"foo", "bar/"},
+			success:     false,
+			err:         "could not find matching URL",
+		},
+		{
+			serviceType: "juju-container-test",
+			version:     "",
+			parts:       []string{"foo", "bar/"},
+			success:     true,
+			URL:         "http://localhost:%s/swift/v1/foo/bar/",
+		},
+		{
+			serviceType: "compute",
+			version:     "",
+			parts:       []string{},
+			success:     false,
+			err:         "could not find matching URL",
+		},
+		{
+			serviceType: "compute",
+			version:     "v25.4",
+			parts:       []string{},
+			success:     false,
+			err:         "could not find matching URL",
+		},
+		{
+			serviceType: "no-such-service",
+			version:     "",
+			parts:       []string{},
+			success:     false,
+			err:         "no endpoints known for service type: no-such-service",
+		},
+	}
+}
+
+func (s *localLiveSuite) TestMakeServiceURL(c *gc.C) {
+	port := "3000"
+	cl := s.assertAuthenticationSuccess(c, port)
+	tests := s.makeServiceURLTests()
+	testCount := len(tests)
+	for i, t := range tests {
+		c.Logf("#%d of %d. %s %s %v", i+1, testCount, t.serviceType, t.version, t.parts)
+		URL, err := cl.MakeServiceURL(t.serviceType, t.version, t.parts)
+		if t.success {
+			c.Assert(err, gc.IsNil)
+			c.Assert(URL, gc.Equals, fmt.Sprintf(t.URL, port))
+			// Run twice to ensure the version caching is working
+			URL, err = cl.MakeServiceURL(t.serviceType, t.version, t.parts)
+			c.Assert(err, gc.IsNil)
+			c.Assert(URL, gc.Equals, fmt.Sprintf(t.URL, port))
+		} else {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		}
+	}
+}
+
+func (s *localLiveSuite) TestMakeServiceURLValues(c *gc.C) {
+	port := "3003"
+	cl := s.assertAuthenticationSuccess(c, port)
+	tests := s.makeServiceURLTests()
+	testCount := len(tests)
+	for i, t := range tests {
+		c.Logf("#%d of %d. %s %s %v", i+1, testCount, t.serviceType, t.version, t.parts)
+		URL, err := cl.MakeServiceURL(t.serviceType, t.version, t.parts)
+		if t.success {
+			c.Assert(err, gc.IsNil)
+			c.Assert(URL, gc.Equals, fmt.Sprintf(t.URL, port))
+			// Run twice to ensure the version caching is working
+			URL, err = cl.MakeServiceURL(t.serviceType, t.version, t.parts)
+			c.Assert(err, gc.IsNil)
+			c.Assert(URL, gc.Equals, fmt.Sprintf(t.URL, port))
+		} else {
+			c.Assert(err, gc.ErrorMatches, t.err)
+		}
+	}
+}
+
+const authInformationBody = `{"versions": [` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v3.4", "links": [{"href": "%s/v3/", "rel": "self"}]},` +
+	`{"status": "stable", "updated": "2014-04-17T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v2.0+json"}], "id": "v2.0", "links": [{"href": "%s/v2.0/", "rel": "self"}, {"href": "http://docs.openstack.org/", "type": "text/html", "rel": "describedby"}]},` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v2.1", "links": [{"href": "%s/v2.1/", "rel": "self"}]}` +
+	`]}`
+
+const authValuesInformationBody = `{"versions": {"values": [` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v3.4", "links": [{"href": "%s/v3/", "rel": "self"}]},` +
+	`{"status": "stable", "updated": "2014-04-17T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v2.0+json"}], "id": "v2.0", "links": [{"href": "%s/v2.0/", "rel": "self"}, {"href": "http://docs.openstack.org/", "type": "text/html", "rel": "describedby"}]},` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v2.1", "links": [{"href": "%s/v2.1/", "rel": "self"}]}` +
+	`]}}`
+
+func (vh *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	body := []byte(fmt.Sprintf(vh.authBody, "http://localhost:"+vh.port, "http://localhost:"+vh.port, "http://localhost:"+vh.port))
+	// workaround for https://code.google.com/p/go/issues/detail?id=4454
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.WriteHeader(http.StatusMultipleChoices)
+	w.Write(body)
+}
+
+func startApiVersionMux(vh versionHandler) string {
+	mux := http.NewServeMux()
+
+	mux.Handle("/", &vh)
+
+	go http.ListenAndServe(":"+vh.port, mux)
+	return fmt.Sprintf("Listening on localhost:%s...\n", vh.port)
+}

--- a/client/live_test.go
+++ b/client/live_test.go
@@ -55,12 +55,19 @@ func (s *LiveTests) TestAuthenticate(c *gc.C) {
 	c.Assert(cl.IsAuthenticated(), gc.Equals, true)
 
 	// Check service endpoints are discovered
-	url, err := cl.MakeServiceURL("compute", nil)
-	c.Check(err, gc.IsNil)
-	c.Check(url, gc.NotNil)
-	url, err = cl.MakeServiceURL("object-store", nil)
-	c.Check(err, gc.IsNil)
-	c.Check(url, gc.NotNil)
+	if s.authMode == identity.AuthLegacy {
+		// AuthLegacy doesn't use the openstack test double, therefore
+		// MakeServiceURL won't work correctly as the endpoint urls are used,
+		// but setup as bad addresses for AuthLegacy
+		c.Log("half of this test will not work with legacy auth")
+	} else {
+		url, err := cl.MakeServiceURL("compute", "v2", nil)
+		c.Check(err, gc.IsNil)
+		c.Check(url, gc.NotNil)
+		url, err = cl.MakeServiceURL("object-store", "", nil)
+		c.Check(err, gc.IsNil)
+		c.Check(url, gc.NotNil)
+	}
 }
 
 func (s *LiveTests) TestAuthDiscover(c *gc.C) {

--- a/glance/glance.go
+++ b/glance/glance.go
@@ -48,7 +48,7 @@ func (c *Client) ListImages() ([]Image, error) {
 		Images []Image
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp, ExpectedStatus: []int{http.StatusOK}}
-	err := c.client.SendRequest(client.GET, "compute", apiImages, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiImages, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of images")
 	}
@@ -86,7 +86,7 @@ func (c *Client) ListImagesDetail() ([]ImageDetail, error) {
 		Images []ImageDetail
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiImagesDetail, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiImagesDetail, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of image details")
 	}
@@ -100,7 +100,7 @@ func (c *Client) GetImageDetail(imageId string) (*ImageDetail, error) {
 	}
 	url := fmt.Sprintf("%s/%s", apiImages, imageId)
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", url, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", url, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get details of imageId: %s", imageId)
 	}

--- a/identity/live_test.go
+++ b/identity/live_test.go
@@ -40,7 +40,7 @@ func (s *LiveTests) TearDownTest(c *gc.C) {
 func (s *LiveTests) TestAuth(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
-	serviceURL, err := s.client.MakeServiceURL("compute", []string{})
+	serviceURL, err := s.client.MakeServiceURL("compute", "v2", []string{})
 	c.Assert(err, gc.IsNil)
 	_, err = url.Parse(serviceURL)
 	c.Assert(err, gc.IsNil)

--- a/identity/local_test.go
+++ b/identity/local_test.go
@@ -1,8 +1,6 @@
 package identity_test
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"strings"
 
@@ -21,46 +19,38 @@ func registerLocalTests(authMode identity.AuthMode) {
 // nova server that runs within the test process itself.
 type localLiveSuite struct {
 	LiveTests
-	// The following attributes are for using testing doubles.
-	Server     *httptest.Server
-	Mux        *http.ServeMux
-	oldHandler http.Handler
+	openstack *openstackservice.Openstack
 }
 
 func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 	c.Logf("Using identity and nova service test doubles")
 
-	// Set up the HTTP server.
-	s.Server = httptest.NewServer(nil)
-	s.oldHandler = s.Server.Config.Handler
-	s.Mux = http.NewServeMux()
-	s.Server.Config.Handler = s.Mux
-
-	serverURL := s.Server.URL
-	if s.authMode == identity.AuthUserPassV3 {
-		serverURL = serverURL + "/v3"
-	}
 	// Set up an Openstack service.
 	s.cred = &identity.Credentials{
-		URL:        serverURL,
 		User:       "fred",
 		Secrets:    "secret",
 		Region:     "zone1.some region",
 		TenantName: "tenant",
 		DomainName: "default",
 	}
-	openstack := openstackservice.New(s.cred, s.authMode)
-	openstack.SetupHTTP(s.Mux)
+	var logMsg []string
+	s.openstack, logMsg = openstackservice.New(s.cred, s.authMode, false)
+	for _, msg := range logMsg {
+		c.Logf(msg)
+	}
+	s.openstack.SetupHTTP(nil)
 
-	openstack.Identity.AddUser("fred", "secret", "tenant")
+	if s.authMode == identity.AuthUserPassV3 {
+		s.cred.URL = s.cred.URL + "/v3"
+	}
+
+	s.openstack.Identity.AddUser("fred", "secret", "tenant")
 	s.LiveTests.SetUpSuite(c)
 }
 
 func (s *localLiveSuite) TearDownSuite(c *gc.C) {
 	s.LiveTests.TearDownSuite(c)
-	s.Mux = nil
-	s.Server.Config.Handler = s.oldHandler
-	s.Server.Close()
+	s.openstack.Stop()
 }
 
 func (s *localLiveSuite) SetUpTest(c *gc.C) {
@@ -76,7 +66,7 @@ func (s *localLiveSuite) TearDownTest(c *gc.C) {
 func (s *localLiveSuite) TestProductStreamsEndpoint(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
-	serviceURL, err := s.client.MakeServiceURL("product-streams", nil)
+	serviceURL, err := s.client.MakeServiceURL("product-streams", "", nil)
 	c.Assert(err, gc.IsNil)
 	_, err = url.Parse(serviceURL)
 	c.Assert(err, gc.IsNil)
@@ -86,7 +76,7 @@ func (s *localLiveSuite) TestProductStreamsEndpoint(c *gc.C) {
 func (s *localLiveSuite) TestJujuToolsEndpoint(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
-	serviceURL, err := s.client.MakeServiceURL("juju-tools", nil)
+	serviceURL, err := s.client.MakeServiceURL("juju-tools", "", nil)
 	c.Assert(err, gc.IsNil)
 	_, err = url.Parse(serviceURL)
 	c.Assert(err, gc.IsNil)

--- a/nova/networks.go
+++ b/nova/networks.go
@@ -34,7 +34,7 @@ func (c *Client) ListNetworks() ([]Network, error) {
 		Networks []Network `json:"networks"`
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiNetworks, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiNetworks, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of networks")
 	}

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -134,7 +134,7 @@ func (c *Client) ListFlavors() ([]Entity, error) {
 		Flavors []Entity
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiFlavors, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiFlavors, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of flavours")
 	}
@@ -175,7 +175,7 @@ func (c *Client) ListFlavorsDetail() ([]FlavorDetail, error) {
 		Flavors []FlavorDetail
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiFlavorsDetail, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiFlavorsDetail, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of flavour details")
 	}
@@ -192,7 +192,7 @@ func (c *Client) ListServers(filter *Filter) ([]Entity, error) {
 		params = &filter.v
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp, Params: params, ExpectedStatus: []int{http.StatusOK}}
-	err := c.client.SendRequest(client.GET, "compute", apiServers, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiServers, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of servers")
 	}
@@ -263,7 +263,7 @@ func (c *Client) ListServersDetail(filter *Filter) ([]ServerDetail, error) {
 		params = &filter.v
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp, Params: params}
-	err := c.client.SendRequest(client.GET, "compute", apiServersDetail, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiServersDetail, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get list of server details")
 	}
@@ -277,7 +277,7 @@ func (c *Client) GetServer(serverId string) (*ServerDetail, error) {
 	}
 	url := fmt.Sprintf("%s/%s", apiServers, serverId)
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", url, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", url, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get details for serverId: %s", serverId)
 	}
@@ -291,7 +291,7 @@ func (c *Client) DeleteServer(serverId string) error {
 	}
 	url := fmt.Sprintf("%s/%s", apiServers, serverId)
 	requestData := goosehttp.RequestData{RespValue: &resp, ExpectedStatus: []int{http.StatusNoContent}}
-	err := c.client.SendRequest(client.DELETE, "compute", url, &requestData)
+	err := c.client.SendRequest(client.DELETE, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to delete server with serverId: %s", serverId)
 	}
@@ -335,7 +335,7 @@ func (c *Client) RunServer(opts RunServerOpts) (*Entity, error) {
 		Server Entity `json:"server"`
 	}
 	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp, ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.POST, "compute", apiServers, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", apiServers, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to run a server with %#v", opts)
 	}
@@ -357,7 +357,7 @@ func (c *Client) UpdateServerName(serverID, name string) (*Entity, error) {
 	req.Server = serverUpdateNameOpts{Name: name}
 	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp, ExpectedStatus: []int{http.StatusOK}}
 	url := fmt.Sprintf("%s/%s", apiServers, serverID)
-	err := c.client.SendRequest(client.PUT, "compute", url, &requestData)
+	err := c.client.SendRequest(client.PUT, "compute", "v2", url, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to update server name to %q", name)
 	}
@@ -397,7 +397,7 @@ func (c *Client) ListSecurityGroups() ([]SecurityGroup, error) {
 		Groups []SecurityGroup `json:"security_groups"`
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiSecurityGroups, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiSecurityGroups, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to list security groups")
 	}
@@ -429,7 +429,7 @@ func (c *Client) GetServerSecurityGroups(serverId string) ([]SecurityGroup, erro
 	}
 	url := fmt.Sprintf("%s/%s/%s", apiServers, serverId, apiSecurityGroups)
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", url, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", url, &requestData)
 	if err != nil {
 		// Sadly HP Cloud lacks the necessary API and also doesn't provide full SecurityGroup lookup.
 		// The best we can do for now is to use just the Id and Name from the group entities.
@@ -466,7 +466,7 @@ func (c *Client) CreateSecurityGroup(name, description string) (*SecurityGroup, 
 		SecurityGroup SecurityGroup `json:"security_group"`
 	}
 	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp, ExpectedStatus: []int{http.StatusOK}}
-	err := c.client.SendRequest(client.POST, "compute", apiSecurityGroups, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", apiSecurityGroups, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to create a security group with name: %s", name)
 	}
@@ -477,7 +477,7 @@ func (c *Client) CreateSecurityGroup(name, description string) (*SecurityGroup, 
 func (c *Client) DeleteSecurityGroup(groupId string) error {
 	url := fmt.Sprintf("%s/%s", apiSecurityGroups, groupId)
 	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.DELETE, "compute", url, &requestData)
+	err := c.client.SendRequest(client.DELETE, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to delete security group with id: %s", groupId)
 	}
@@ -499,7 +499,7 @@ func (c *Client) UpdateSecurityGroup(groupId, name, description string) (*Securi
 	}
 	url := fmt.Sprintf("%s/%s", apiSecurityGroups, groupId)
 	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp, ExpectedStatus: []int{http.StatusOK}}
-	err := c.client.SendRequest(client.PUT, "compute", url, &requestData)
+	err := c.client.SendRequest(client.PUT, "compute", "v2", url, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to update security group with Id %s to name: %s", groupId, name)
 	}
@@ -564,7 +564,7 @@ func (c *Client) CreateSecurityGroupRule(ruleInfo RuleInfo) (*SecurityGroupRule,
 	}
 
 	requestData := goosehttp.RequestData{ReqValue: req, RespValue: &resp}
-	err := c.client.SendRequest(client.POST, "compute", apiSecurityGroupRules, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", apiSecurityGroupRules, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to create a rule for the security group with id: %v", ruleInfo.GroupId)
 	}
@@ -575,7 +575,7 @@ func (c *Client) CreateSecurityGroupRule(ruleInfo RuleInfo) (*SecurityGroupRule,
 func (c *Client) DeleteSecurityGroupRule(ruleId string) error {
 	url := fmt.Sprintf("%s/%s", apiSecurityGroupRules, ruleId)
 	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.DELETE, "compute", url, &requestData)
+	err := c.client.SendRequest(client.DELETE, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to delete security group rule with id: %s", ruleId)
 	}
@@ -593,7 +593,7 @@ func (c *Client) AddServerSecurityGroup(serverId, groupName string) error {
 
 	url := fmt.Sprintf("%s/%s/action", apiServers, serverId)
 	requestData := goosehttp.RequestData{ReqValue: req, ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to add security group '%s' to server with id: %s", groupName, serverId)
 	}
@@ -611,7 +611,7 @@ func (c *Client) RemoveServerSecurityGroup(serverId, groupName string) error {
 
 	url := fmt.Sprintf("%s/%s/action", apiServers, serverId)
 	requestData := goosehttp.RequestData{ReqValue: req, ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to remove security group '%s' from server with id: %s", groupName, serverId)
 	}
@@ -637,7 +637,7 @@ func (c *Client) ListFloatingIPs() ([]FloatingIP, error) {
 	}
 
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiFloatingIPs, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiFloatingIPs, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to list floating ips")
 	}
@@ -652,7 +652,7 @@ func (c *Client) GetFloatingIP(ipId string) (*FloatingIP, error) {
 
 	url := fmt.Sprintf("%s/%s", apiFloatingIPs, ipId)
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", url, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", url, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to get floating ip %s details", ipId)
 	}
@@ -666,7 +666,7 @@ func (c *Client) AllocateFloatingIP() (*FloatingIP, error) {
 	}
 
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.POST, "compute", apiFloatingIPs, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", apiFloatingIPs, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to allocate a floating ip")
 	}
@@ -677,7 +677,7 @@ func (c *Client) AllocateFloatingIP() (*FloatingIP, error) {
 func (c *Client) DeleteFloatingIP(ipId string) error {
 	url := fmt.Sprintf("%s/%s", apiFloatingIPs, ipId)
 	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.DELETE, "compute", url, &requestData)
+	err := c.client.SendRequest(client.DELETE, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to delete floating ip %s details", ipId)
 	}
@@ -695,7 +695,7 @@ func (c *Client) AddServerFloatingIP(serverId, address string) error {
 
 	url := fmt.Sprintf("%s/%s/action", apiServers, serverId)
 	requestData := goosehttp.RequestData{ReqValue: req, ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to add floating ip %s to server with id: %s", address, serverId)
 	}
@@ -713,7 +713,7 @@ func (c *Client) RemoveServerFloatingIP(serverId, address string) error {
 
 	url := fmt.Sprintf("%s/%s/action", apiServers, serverId)
 	requestData := goosehttp.RequestData{ReqValue: req, ExpectedStatus: []int{http.StatusAccepted}}
-	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to remove floating ip %s from server with id: %s", address, serverId)
 	}
@@ -741,7 +741,7 @@ func (c *Client) ListAvailabilityZones() ([]AvailabilityZone, error) {
 		AvailabilityZoneInfo []AvailabilityZone
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "compute", apiAvailabilityZone, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", apiAvailabilityZone, &requestData)
 	if errors.IsNotFound(err) {
 		// Availability zones are an extension, so don't
 		// return an error if the API does not exist.
@@ -784,7 +784,7 @@ func (c *Client) AttachVolume(serverId, volumeId, device string) (*VolumeAttachm
 		RespValue: &resp,
 	}
 	url := fmt.Sprintf("%s/%s/%s", apiServers, serverId, apiVolumeAttachments)
-	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
 	if errors.IsNotFound(err) {
 		return nil, errors.NewNotImplementedf(
 			err, nil, "the server does not support attaching volumes",
@@ -803,7 +803,7 @@ func (c *Client) DetachVolume(serverId, attachmentId string) error {
 		ExpectedStatus: []int{http.StatusAccepted},
 	}
 	url := fmt.Sprintf("%s/%s/%s/%s", apiServers, serverId, apiVolumeAttachments, attachmentId)
-	err := c.client.SendRequest(client.DELETE, "compute", url, &requestData)
+	err := c.client.SendRequest(client.DELETE, "compute", "v2", url, &requestData)
 	if errors.IsNotFound(err) {
 		return errors.NewNotImplementedf(
 			err, nil, "the server does not support deleting attached volumes",
@@ -826,7 +826,7 @@ func (c *Client) ListVolumeAttachments(serverId string) ([]VolumeAttachment, err
 		RespValue: &resp,
 	}
 	url := fmt.Sprintf("%s/%s/%s", apiServers, serverId, apiVolumeAttachments)
-	err := c.client.SendRequest(client.GET, "compute", url, &requestData)
+	err := c.client.SendRequest(client.GET, "compute", "v2", url, &requestData)
 	if errors.IsNotFound(err) {
 		return nil, errors.NewNotImplementedf(
 			err, nil, "the server does not support listing attached volumes",
@@ -848,7 +848,7 @@ func (c *Client) SetServerMetadata(serverId string, metadata map[string]string) 
 	requestData := goosehttp.RequestData{
 		ReqValue: req, ExpectedStatus: []int{http.StatusOK},
 	}
-	err := c.client.SendRequest(client.POST, "compute", url, &requestData)
+	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to set metadata %v on server with id: %s", metadata, serverId)
 	}

--- a/swift/live_test.go
+++ b/swift/live_test.go
@@ -164,7 +164,7 @@ func (s *LiveTestsPublicContainer) TearDownSuite(c *gc.C) {
 func (s *LiveTestsPublicContainer) SetUpTest(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
-	baseURL, err := s.client.MakeServiceURL("object-store", nil)
+	baseURL, err := s.client.MakeServiceURL("object-store", "", nil)
 	c.Assert(err, gc.IsNil)
 	s.publicClient = client.NewPublicClient(baseURL, nil)
 	s.publicSwift = swift.New(s.publicClient)

--- a/swift/local_test.go
+++ b/swift/local_test.go
@@ -34,8 +34,13 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 		TenantName: "tenant",
 	}
 	s.LiveTestsPublicContainer.cred = s.LiveTests.cred
-	s.openstack = openstackservice.New(s.LiveTests.cred,
-		identity.AuthUserPass)
+	var logMsg []string
+	s.openstack, logMsg = openstackservice.New(s.LiveTests.cred,
+		identity.AuthUserPass, false)
+	for _, msg := range logMsg {
+		c.Logf(msg)
+	}
+	s.openstack.SetupHTTP(nil)
 
 	s.LiveTests.SetUpSuite(c)
 	s.LiveTestsPublicContainer.SetUpSuite(c)
@@ -49,7 +54,6 @@ func (s *localLiveSuite) TearDownSuite(c *gc.C) {
 
 func (s *localLiveSuite) SetUpTest(c *gc.C) {
 	s.HTTPSuite.SetUpTest(c)
-	s.openstack.SetupHTTP(s.Mux)
 	s.LiveTests.SetUpTest(c)
 	s.LiveTestsPublicContainer.SetUpTest(c)
 }

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -39,7 +39,7 @@ func (c *Client) CreateContainer(containerName string, acl ACL) error {
 	// [sodre]: Due to a possible bug in ceph-radosgw, we need to split the
 	// creation of the bucket and the changing its ACL.
 	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusAccepted, http.StatusCreated}}
-	err := c.client.SendRequest(client.PUT, "object-store", containerName, &requestData)
+	err := c.client.SendRequest(client.PUT, "object-store", "", containerName, &requestData)
 	if err != nil {
 		err = maybeNotFound(err, "failed to create container: %s", containerName)
 		return err
@@ -51,7 +51,7 @@ func (c *Client) CreateContainer(containerName string, acl ACL) error {
 	headers.Add("X-Container-Read", string(acl))
 	requestData = goosehttp.RequestData{ReqHeaders: headers,
 		ExpectedStatus: []int{http.StatusAccepted, http.StatusNoContent}}
-	err = c.client.SendRequest(client.POST, "object-store", containerName, &requestData)
+	err = c.client.SendRequest(client.POST, "object-store", "", containerName, &requestData)
 	if err != nil {
 		err = maybeNotFound(err, "failed to update container read acl: %s", containerName)
 	}
@@ -61,7 +61,7 @@ func (c *Client) CreateContainer(containerName string, acl ACL) error {
 // DeleteContainer deletes the specified container.
 func (c *Client) DeleteContainer(containerName string) error {
 	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusNoContent}}
-	err := c.client.SendRequest(client.DELETE, "object-store", containerName, &requestData)
+	err := c.client.SendRequest(client.DELETE, "object-store", "", containerName, &requestData)
 	if err != nil {
 		err = maybeNotFound(err, "failed to delete container: %s", containerName)
 	}
@@ -70,7 +70,7 @@ func (c *Client) DeleteContainer(containerName string) error {
 
 func (c *Client) touchObject(requestData *goosehttp.RequestData, op, containerName, objectName string) error {
 	path := fmt.Sprintf("%s/%s", containerName, objectName)
-	err := c.client.SendRequest(op, "object-store", path, requestData)
+	err := c.client.SendRequest(op, "object-store", "", path, requestData)
 	if err != nil {
 		err = maybeNotFound(err, "failed to %s object %s from container %s", op, objectName, containerName)
 	}
@@ -150,7 +150,7 @@ func (c *Client) List(containerName, prefix, delim, marker string, limit int) (c
 	}
 
 	requestData := goosehttp.RequestData{Params: &params, RespValue: &contents}
-	err = c.client.SendRequest(client.GET, "object-store", containerName, &requestData)
+	err = c.client.SendRequest(client.GET, "object-store", "", containerName, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to list contents of container: %s", containerName)
 	}
@@ -160,7 +160,7 @@ func (c *Client) List(containerName, prefix, delim, marker string, limit int) (c
 // URL returns a non-signed URL that allows retrieving the object at path.
 // It only works if the object is publicly readable (see SignedURL).
 func (c *Client) URL(containerName, file string) (string, error) {
-	return c.client.MakeServiceURL("object-store", []string{containerName, file})
+	return c.client.MakeServiceURL("object-store", "", []string{containerName, file})
 }
 
 // SignedURL returns a signed URL that allows anyone holding the URL

--- a/test.py
+++ b/test.py
@@ -48,7 +48,7 @@ def create_tarmac_repository():
     if b.repository.is_shared():
         return
     pwd = os.getcwd()
-    expected_dir = 'src/launchpad.net/'
+    expected_dir = 'src/github.com/'
     offset = pwd.rfind(expected_dir)
     if offset == -1:
         sys.stderr.write('Could not find %r to create a shared repo\n')
@@ -88,11 +88,11 @@ def ensure_juju_core_dependencies():
     # latest juju-core and everything else. The other is where the
     # goose-under-test resides. So we don't add the goose-under-test to GOPATH,
     # call "go get", then add it to the GOPATH for the rest of the testing.
-    cmd = ['go', 'get', '-u', '-x', 'launchpad.net/juju-core/...']
+    cmd = ['go', 'get', '-u', '-x', 'github.com/juju/...']
     sys.stderr.write('Running: %s\n' % (' '.join(cmd),))
     retcode = subprocess.call(cmd)
     if retcode != 0:
-        sys.stderr.write('WARN: Failed to update launchpad.net/juju-core\n')
+        sys.stderr.write('WARN: Failed to update github.com/juju\n')
 
 
 def tarmac_setup(opts):

--- a/testservices/cmd/main.go
+++ b/testservices/cmd/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"launchpad.net/gnuflag"
+	"github.com/juju/gnuflag"
 
 	"gopkg.in/goose.v1/testservices/identityservice"
 )

--- a/testservices/identityservice/keypair.go
+++ b/testservices/identityservice/keypair.go
@@ -120,3 +120,7 @@ func (u *KeyPair) generateAccessResponse(userInfo *UserInfo) (*AccessResponse, e
 func (u *KeyPair) SetupHTTP(mux *http.ServeMux) {
 	mux.Handle("/tokens", u)
 }
+
+func (u *KeyPair) Stop() {
+	// noop
+}

--- a/testservices/identityservice/legacy.go
+++ b/testservices/identityservice/legacy.go
@@ -33,6 +33,10 @@ func (lis *Legacy) SetupHTTP(mux *http.ServeMux) {
 	mux.Handle("/", lis)
 }
 
+func (lis *Legacy) Stop() {
+	// NOOP for legacy identity service.
+}
+
 func (lis *Legacy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	username := r.Header.Get("X-Auth-User")
 	userInfo, ok := lis.users[username]

--- a/testservices/identityservice/userpass.go
+++ b/testservices/identityservice/userpass.go
@@ -254,3 +254,7 @@ func (u *UserPass) generateAccessResponse(userInfo *UserInfo) (*AccessResponse, 
 func (u *UserPass) SetupHTTP(mux *http.ServeMux) {
 	mux.Handle("/tokens", u)
 }
+
+func (u *UserPass) Stop() {
+	// noop
+}

--- a/testservices/identityservice/v3userpass.go
+++ b/testservices/identityservice/v3userpass.go
@@ -214,3 +214,7 @@ func (u *V3UserPass) generateV3TokenResponse(userInfo *UserInfo) (*V3TokenRespon
 func (u *V3UserPass) SetupHTTP(mux *http.ServeMux) {
 	mux.Handle("/v3/auth/tokens", u)
 }
+
+func (u *V3UserPass) Stop() {
+	// noop
+}

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -143,6 +143,10 @@ func New(hostURL, versionPath, tenantId, region string, identityService, fallbac
 	return novaService
 }
 
+func (n *Nova) Stop() {
+	// noop
+}
+
 // SetAvailabilityZones sets the availability zones for setting
 // availability zones.
 //

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -167,8 +167,8 @@ The resource could not be found.
 	}
 	errNoVersion = &errorResponse{
 		http.StatusOK,
-		`{"versions": [{"status": "CURRENT", "updated": "2011-01-21` +
-			`T11:33:21Z", "id": "v2.0", "links": [{"href": "$ENDPOINT$", "rel": "self"}]}]}`,
+		`{"versions": [` +
+			`{"id": "v2.0", "links": [{"href": "v2", "rel": "self"}], "status": "SUPPORTED", "updated": "2011-01-21T11:33:21Z"}]}`,
 		"application/json",
 		"no version specified in URL",
 		nil,
@@ -1255,4 +1255,8 @@ func (n *Nova) SetupHTTP(mux *http.ServeMux) {
 		}
 		mux.Handle(path, h)
 	}
+}
+
+func (n *Nova) SetupRootHandler(mux *http.ServeMux) {
+	mux.Handle("/", n.handler((*Nova).handleRoot))
 }

--- a/testservices/service.go
+++ b/testservices/service.go
@@ -10,6 +10,7 @@ import (
 // An HttpService provides the HTTP API for a service double.
 type HttpService interface {
 	SetupHTTP(mux *http.ServeMux)
+	Stop()
 }
 
 // A ServiceInstance is an Openstack module, one of nova, swift, glance.

--- a/testservices/swiftservice/service.go
+++ b/testservices/swiftservice/service.go
@@ -55,8 +55,17 @@ func New(hostURL, versionPath, tenantId, region string, identityService, fallbac
 	return swift
 }
 
+func Stop() {
+	// noop
+}
+
 func (s *Swift) endpointURL(path string) string {
-	ep := s.Scheme + "://" + s.Hostname + s.VersionPath + "/" + s.TenantId
+	// Note: We're using the Openstack Style endpoints for this testservice
+	// 	Openstack object-storage endpoint url:
+	// 	http://<ip addr>:<port>/swift/v1
+	// 	Rackspace object-storage endpoint url:
+	// 	https://<rackspace addr>/v1/MossoCloudFS_<tenant id>
+	ep := s.Scheme + "://" + s.Hostname + "swift/" + s.VersionPath
 	if path != "" {
 		ep += "/" + strings.TrimLeft(path, "/")
 	}

--- a/testservices/swiftservice/service_http.go
+++ b/testservices/swiftservice/service_http.go
@@ -4,7 +4,6 @@ package swiftservice
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -193,14 +192,16 @@ func (s *Swift) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimRight(r.URL.Path, "/")
 	path = strings.Trim(path, "/")
 	parts := strings.SplitN(path, "/", 4)
-	parts = parts[2:]
-	if len(parts) == 1 {
-		container := parts[0]
-		s.handleContainers(container, w, r)
-	} else if len(parts) == 2 {
-		container := parts[0]
-		object := parts[1]
-		s.handleObjects(container, object, w, r)
+	if len(parts) > 2 {
+		parts = parts[2:]
+		if len(parts) == 1 {
+			container := parts[0]
+			s.handleContainers(container, w, r)
+		} else if len(parts) == 2 {
+			container := parts[0]
+			object := parts[1]
+			s.handleObjects(container, object, w, r)
+		}
 	} else {
 		panic("not implemented request: " + r.URL.Path)
 	}
@@ -208,6 +209,9 @@ func (s *Swift) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // setupHTTP attaches all the needed handlers to provide the HTTP API.
 func (s *Swift) SetupHTTP(mux *http.ServeMux) {
-	path := fmt.Sprintf("/%s/%s/", s.VersionPath, s.TenantId)
-	mux.Handle(path, s)
+	mux.Handle("/", s)
+}
+
+func (s *Swift) Stop() {
+	// noop
 }

--- a/testservices/swiftservice/service_test.go
+++ b/testservices/swiftservice/service_test.go
@@ -80,7 +80,7 @@ func (s *SwiftServiceSuite) TestGetURL(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	url, err := s.service.GetURL("test", "obj")
 	c.Assert(err, gc.IsNil)
-	c.Assert(url, gc.Equals, fmt.Sprintf("%s/%s/%s/test/obj", hostname, versionPath, tenantId))
+	c.Assert(url, gc.Equals, fmt.Sprintf("%s/swift/%s/test/obj", hostname, versionPath))
 	err = s.service.RemoveContainer("test")
 	c.Assert(err, gc.IsNil)
 	ok = s.service.HasContainer("test")

--- a/tools/secgroup-delete-all/main.go
+++ b/tools/secgroup-delete-all/main.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"launchpad.net/gnuflag"
+	"github.com/juju/gnuflag"
 
 	"gopkg.in/goose.v1/client"
 	"gopkg.in/goose.v1/identity"

--- a/tools/secgroup-delete-all/main_test.go
+++ b/tools/secgroup-delete-all/main_test.go
@@ -47,7 +47,7 @@ func (s *ToolSuite) makeServices(c *gc.C) (*openstackservice.Openstack, *nova.Cl
 		Region:     region,
 		TenantName: tenant,
 	}
-	openstack := openstackservice.New(creds, identity.AuthUserPass)
+	openstack, _ := openstackservice.New(creds, identity.AuthUserPass, false)
 	openstack.SetupHTTP(s.Mux)
 	return openstack, createNovaClientFromCreds(creds)
 }


### PR DESCRIPTION
…re calls

This is a step on the way to API updates to include neutron replacements for deprecated nova API calls.  There is a corresponding commit required by juju.

The POC was from: https://github.com/axw/goose/commit/a7c4a4ef9d936eb113e6ab1c0d2af4612467cedb

Rackspace and OpenStack get the same results with swift testservice (local and live).  Nova testservice has a bug so the live tests won't run there.  Identity (live) testservice tests have a permission problem I haven't been able to work out yet, that doesn't occur in real life.  juju deploy with this code and the corresponding juju PR works for both Rackspace and OpenStack.
