### PR TITLE
client: don't do version discovery when version=""

### DIFF
--- a/client/apiversion_test.go
+++ b/client/apiversion_test.go
@@ -25,6 +25,16 @@ type makeServiceURLTest struct {
 func (s *localLiveSuite) makeServiceURLTests() []makeServiceURLTest {
 	return []makeServiceURLTest{
 		{
+			// As a special case, if no version is specified
+			// then we use whatever URL is recoded in the
+			// service catalogue verbatim.
+			serviceType: "compute",
+			version:     "",
+			parts:       []string{},
+			success:     true,
+			URL:         "http://localhost:%s",
+		},
+		{
 			serviceType: "compute",
 			version:     "v2.1",
 			parts:       []string{"foo", "bar/"},
@@ -93,13 +103,6 @@ func (s *localLiveSuite) makeServiceURLTests() []makeServiceURLTest {
 			parts:       []string{"foo", "bar/"},
 			success:     true,
 			URL:         "http://localhost:%s/swift/v1/foo/bar/",
-		},
-		{
-			serviceType: "compute",
-			version:     "",
-			parts:       []string{},
-			success:     false,
-			err:         "could not find matching URL",
 		},
 		{
 			serviceType: "compute",

--- a/client/client.go
+++ b/client/client.go
@@ -204,7 +204,10 @@ func (c *authenticatingClient) sendAuthRequest(
 
 // MakeServiceURL uses an endpoint matching the apiVersion for the given service type.
 // Given a major version only, the version with the highest minor will be used.
-// object-store and container service types have no versions
+//
+// object-store and container service types have no versions. For these services, the
+// caller may pass "" for apiVersion, to use the service catalogue URL without any
+// version discovery.
 func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, parts []string) (string, error) {
 	if !c.IsAuthenticated() {
 		return "", errors.New("cannot get endpoint URL without being authenticated")
@@ -212,6 +215,9 @@ func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, pa
 	serviceURL, ok := c.serviceURLs[serviceType]
 	if !ok {
 		return "", errors.New("no endpoints known for service type: " + serviceType)
+	}
+	if apiVersion == "" {
+		return makeURL(serviceURL, parts), nil
 	}
 	requestedVersion, err := parseVersion(apiVersion)
 	if err != nil {


### PR DESCRIPTION
If the user specifies no API version at all, don't
perform version discovery, and just return the URL
reported by the authentication response. This is to
support Juju's use of the "product-streams" service
entry for simplestreams data.
