### PR TITLE
nova: omit "id" and "serverId" from attach request

### DIFF
--- a/nova/nova.go
+++ b/nova/nova.go
@@ -759,8 +759,8 @@ func (c *Client) ListAvailabilityZones() ([]AvailabilityZone, error) {
 // attaching volumes.
 type VolumeAttachment struct {
 	Device   *string `json:"device,omitempty"`
-	Id       string  `json:"id"`
-	ServerId string  `json:"serverId"`
+	Id       string  `json:"id,omitempty"`
+	ServerId string  `json:"serverId,omitempty"`
 	VolumeId string  `json:"volumeId"`
 }
 
@@ -782,7 +782,6 @@ func (c *Client) AttachVolume(serverId, volumeId, device string) (*VolumeAttachm
 	var resp volumeAttachment
 	requestData := goosehttp.RequestData{
 		ReqValue: &volumeAttachment{VolumeAttachment{
-			ServerId: serverId,
 			VolumeId: volumeId,
 			Device:   devicePtr,
 		}},

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -1207,8 +1207,28 @@ func (n *Nova) handleAttachVolumes(w http.ResponseWriter, r *http.Request) error
 		}
 	}
 
+	var additionalProperties []string
+	if attachment.VolumeAttachment.ServerId != "" {
+		additionalProperties = append(additionalProperties, "'serverId'")
+	}
+	if len(additionalProperties) > 0 {
+		message := fmt.Sprintf(
+			"Additional properties are not allowed (%s were unexpected)",
+			strings.Join(additionalProperties, ", "),
+		)
+		return &errorResponse{
+			http.StatusBadRequest,
+			fmt.Sprintf(`{"badRequest": {"message": "%s", "code": 400}}`, message),
+			"application/json; charset=UTF-8",
+			message,
+			nil,
+			nil,
+		}
+	}
+
 	n.nextAttachmentId++
 	attachment.VolumeAttachment.Id = fmt.Sprintf("%d", n.nextAttachmentId)
+	attachment.VolumeAttachment.ServerId = serverId
 
 	serverVols := n.serverIdToAttachedVolumes[serverId]
 	serverVols = append(serverVols, attachment.VolumeAttachment)


### PR DESCRIPTION
When POSTing to os-volume_attachments, we should not
be passing anything for "id" or "serverId". Set these
to omitempty.