### PR TITLE
client: add method to disable version discovery

### DIFF
--- a/client/apiversion_test.go
+++ b/client/apiversion_test.go
@@ -142,6 +142,17 @@ func (s *localLiveSuite) TestMakeServiceURL(c *gc.C) {
 	}
 }
 
+func (s *localLiveSuite) TestMakeServiceURLAPIVersionDiscoveryDisabled(c *gc.C) {
+	port := "3000"
+	cl := s.assertAuthenticationSuccess(c, port)
+	wasEnabled := cl.SetVersionDiscoveryEnabled(false)
+	c.Assert(wasEnabled, gc.Equals, true)
+
+	url, err := cl.MakeServiceURL("compute", "v2.1", []string{"foo", "bar/"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(url, gc.Equals, fmt.Sprintf("http://localhost:%s/foo/bar/", port))
+}
+
 func (s *localLiveSuite) TestMakeServiceURLValues(c *gc.C) {
 	port := "3003"
 	cl := s.assertAuthenticationSuccess(c, port)

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -242,7 +242,7 @@ func (s *localLiveSuite) TestAuthenticationTimeout(c *gc.C) {
 	c.Assert(errors.IsTimeout(err), gc.Equals, true)
 }
 
-func (s *localLiveSuite) assertAuthenticationSuccess(c *gc.C, port string) client.Client {
+func (s *localLiveSuite) assertAuthenticationSuccess(c *gc.C, port string) client.AuthenticatingClient {
 	cl := client.NewClient(s.cred, s.authMode, nil)
 	cl.SetRequiredServiceTypes([]string{"compute"})
 	defer client.SetAuthenticationTimeout(2 * time.Millisecond)()


### PR DESCRIPTION
Add AuthenticatingClient.SetVersionDiscoveryEnabled
so package users can disable API version discovery,
to revert back to the old behaviour.