### PR TITLE
Handle 404 in version discovery gracefully

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -258,6 +258,13 @@ func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, pa
 	if err != nil {
 		return "", err
 	}
+	if len(apiURLVersionInfo.versions) == 0 {
+		// There is no API version information for this service,
+		// so just use the service URL as if discovery were
+		// disabled. This isn't guaranteed to result in a valid
+		// endpoint, but it's the best we can do.
+		return makeURL(serviceURL, parts), nil
+	}
 	serviceURL, err = getAPIVersionURL(apiURLVersionInfo, requestedVersion)
 	if err != nil {
 		return "", err

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -184,10 +184,13 @@ func (s *localLiveSuite) doNewAuthenticator(c *gc.C, bufsize int, port string) *
 	newAuth.mu.Lock()
 	if _, ok := s.versionHandlers[port]; !ok {
 		var vh versionHandler
-		if port == "3000" {
+		switch port {
+		case "3000":
 			vh.authBody = authInformationBody
-		} else if port == "3003" {
+		case "3003":
 			vh.authBody = authValuesInformationBody
+		case "3005":
+			vh.authBody = ""
 		}
 		vh.port = port
 		c.Logf(startApiVersionMux(vh))


### PR DESCRIPTION
If, when attempting API version discovery, we receive
a 404 response when querying the root endpoint, we
should not prevent the API request. Instead, revert
to the old behaviour of using the service catalogue's
public URL entry as-is.