### PR TITLE
Add SetVolumeMetadata to cinder.Client

### DIFF
--- a/cinder/client.go
+++ b/cinder/client.go
@@ -296,3 +296,14 @@ func (c *Client) SnapshotStatusNotifier(snapId, status string, numAttempts int, 
 	}
 	return notifier(statusMatches, numAttempts, waitDur)
 }
+
+// SetVolumeMetadata sets metadata on a server. Replaces metadata
+// items that match keys - doesn't modify items that aren't in the
+// request. Returns the complete, updated metadata for the volume.
+func (c *Client) SetVolumeMetadata(volumeId string, metadata map[string]string) (map[string]string, error) {
+	response, err := updateVolumeMetadata(c, volumeId, &UpdateVolumeMetadataParams{metadata})
+	if err != nil {
+		return nil, err
+	}
+	return response.Metadata, nil
+}

--- a/client/apiversion.go
+++ b/client/apiversion.go
@@ -226,7 +226,7 @@ func (c *authenticatingClient) getAPIVersions(serviceCatalogURL string) (*apiURL
 		return nil, err
 	}
 	apiURLVersionInfo.versions = versions
-	logger.Warningf("discovered API versions: %+v", versions)
+	logger.Debugf("discovered API versions: %+v", versions)
 
 	// Cache the result.
 	c.apiURLVersions[baseURL] = apiURLVersionInfo

--- a/nova/live_test.go
+++ b/nova/live_test.go
@@ -627,6 +627,9 @@ func (s *LiveTests) TestSetServerMetadata(c *gc.C) {
 	}, {
 		"k1": "v1.replacement",
 		"k2": "v2",
+	}, {
+		// Check that missing keys get left alone.
+		"k2": "v2.replacement",
 	}} {
 		err = s.nova.SetServerMetadata(entity.Id, metadata)
 		c.Assert(err, gc.IsNil)
@@ -635,5 +638,5 @@ func (s *LiveTests) TestSetServerMetadata(c *gc.C) {
 	server, err := s.nova.GetServer(entity.Id)
 	c.Assert(err, gc.IsNil)
 	c.Assert(server.Metadata["k1"], gc.Equals, "v1.replacement")
-	c.Assert(server.Metadata["k2"], gc.Equals, "v2")
+	c.Assert(server.Metadata["k2"], gc.Equals, "v2.replacement")
 }

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -843,7 +843,10 @@ func (c *Client) ListVolumeAttachments(serverId string) ([]VolumeAttachment, err
 	return resp.VolumeAttachments, nil
 }
 
-// SetServerMetadata sets metadata on a server.
+// SetServerMetadata sets metadata on a server. Replaces metadata
+// items that match keys - doesn't modify items that aren't in the
+// request.
+// See https://developer.openstack.org/api-ref/compute/?expanded=update-metadata-items-detail#update-metadata-items
 func (c *Client) SetServerMetadata(serverId string, metadata map[string]string) error {
 	req := struct {
 		Metadata map[string]string `json:"metadata"`


### PR DESCRIPTION
This allows updating the tags for a volume.

Will be used by Juju after a successful migration to update the owning controller for the volume.
Part of fixing https://bugs.launchpad.net/juju/+bug/1648063

Includes a drive-by to make some debug logging not be a warning. 