### PR TITLE
Add missing support for keystone v3 project domain in auth

### DIFF
--- a/client/local_test.go
+++ b/client/local_test.go
@@ -48,11 +48,12 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 	c.Logf("Using identity service test double")
 	s.HTTPSuite.SetUpSuite(c)
 	s.cred = &identity.Credentials{
-		URL:        s.Server.URL,
-		User:       "fred",
-		Secrets:    "secret",
-		Region:     "zone1.some region",
-		TenantName: "tenant",
+		URL:           s.Server.URL,
+		User:          "fred",
+		Secrets:       "secret",
+		Region:        "zone1.some region",
+		TenantName:    "tenant",
+		ProjectDomain: "default",
 	}
 	var logMsg []string
 	switch s.authMode {
@@ -98,7 +99,7 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 
 	case identity.AuthLegacy:
 		legacy := identityservice.NewLegacy()
-		legacy.AddUser(s.cred.User, s.cred.Secrets, s.cred.TenantName)
+		legacy.AddUser(s.cred.User, s.cred.Secrets, s.cred.TenantName, "default")
 		legacy.SetManagementURL("http://management.test.invalid/url")
 		s.service = legacy
 	}

--- a/identity/legacy_test.go
+++ b/identity/legacy_test.go
@@ -16,7 +16,7 @@ var _ = gc.Suite(&LegacyTestSuite{})
 func (s *LegacyTestSuite) TestAuthAgainstServer(c *gc.C) {
 	service := identityservice.NewLegacy()
 	s.Mux.Handle("/", service)
-	userInfo := service.AddUser("joe-user", "secrets", "tenant")
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
 	service.SetManagementURL("http://management.test.invalid/url")
 	var l Authenticator = &Legacy{}
 	creds := Credentials{User: "joe-user", URL: s.Server.URL, Secrets: "secrets"}
@@ -32,7 +32,7 @@ func (s *LegacyTestSuite) TestAuthAgainstServer(c *gc.C) {
 func (s *LegacyTestSuite) TestBadAuth(c *gc.C) {
 	service := identityservice.NewLegacy()
 	s.Mux.Handle("/", service)
-	_ = service.AddUser("joe-user", "secrets", "tenant")
+	_ = service.AddUser("joe-user", "secrets", "tenant", "default")
 	var l Authenticator = &Legacy{}
 	creds := Credentials{User: "joe-user", URL: s.Server.URL, Secrets: "bad-secrets"}
 	auth, err := l.Auth(&creds)

--- a/identity/local_test.go
+++ b/identity/local_test.go
@@ -31,7 +31,6 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 		Secrets:    "secret",
 		Region:     "zone1.some region",
 		TenantName: "tenant",
-		DomainName: "default",
 	}
 	var logMsg []string
 	s.openstack, logMsg = openstackservice.New(s.cred, s.authMode, false)
@@ -44,7 +43,7 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 		s.cred.URL = s.cred.URL + "/v3"
 	}
 
-	s.openstack.Identity.AddUser("fred", "secret", "tenant")
+	s.openstack.Identity.AddUser("fred", "secret", "tenant", "default")
 	s.LiveTests.SetUpSuite(c)
 }
 

--- a/identity/userpass_test.go
+++ b/identity/userpass_test.go
@@ -16,7 +16,7 @@ var _ = gc.Suite(&UserPassTestSuite{})
 func (s *UserPassTestSuite) TestAuthAgainstServer(c *gc.C) {
 	service := identityservice.NewUserPass()
 	service.SetupHTTP(s.Mux)
-	userInfo := service.AddUser("joe-user", "secrets", "tenant")
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
 	var l Authenticator = &UserPass{}
 	creds := Credentials{User: "joe-user", URL: s.Server.URL + "/tokens", Secrets: "secrets"}
 	auth, err := l.Auth(&creds)
@@ -29,7 +29,7 @@ func (s *UserPassTestSuite) TestAuthAgainstServer(c *gc.C) {
 func (s *UserPassTestSuite) TestRegionMatch(c *gc.C) {
 	service := identityservice.NewUserPass()
 	service.SetupHTTP(s.Mux)
-	userInfo := service.AddUser("joe-user", "secrets", "tenant")
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
 	serviceDef := identityservice.V2Service{
 		Name: "swift",
 		Type: "object-store",

--- a/identity/v3userpass_test.go
+++ b/identity/v3userpass_test.go
@@ -16,7 +16,7 @@ var _ = gc.Suite(&V3UserPassTestSuite{})
 func (s *V3UserPassTestSuite) TestAuthAgainstServer(c *gc.C) {
 	service := identityservice.NewV3UserPass()
 	service.SetupHTTP(s.Mux)
-	userInfo := service.AddUser("joe-user", "secrets", "tenant")
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
 	var l Authenticator = &V3UserPass{}
 	creds := Credentials{
 		User:    "joe-user",
@@ -31,13 +31,14 @@ func (s *V3UserPassTestSuite) TestAuthAgainstServer(c *gc.C) {
 func (s *V3UserPassTestSuite) TestAuthToAProject(c *gc.C) {
 	service := identityservice.NewV3UserPass()
 	service.SetupHTTP(s.Mux)
-	userInfo := service.AddUser("joe-user", "secrets", "tenant")
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "project-domain")
 	var l Authenticator = &V3UserPass{}
 	creds := Credentials{
-		User:       "joe-user",
-		URL:        s.Server.URL + "/v3/auth/tokens",
-		Secrets:    "secrets",
-		TenantName: "tenant",
+		User:          "joe-user",
+		URL:           s.Server.URL + "/v3/auth/tokens",
+		Secrets:       "secrets",
+		TenantName:    "tenant",
+		ProjectDomain: "project-domain",
 	}
 	auth, err := l.Auth(&creds)
 	c.Assert(err, gc.IsNil)
@@ -45,10 +46,28 @@ func (s *V3UserPassTestSuite) TestAuthToAProject(c *gc.C) {
 	c.Assert(auth.TenantId, gc.Equals, userInfo.TenantId)
 }
 
+func (s *V3UserPassTestSuite) TestAuthToADomain(c *gc.C) {
+	service := identityservice.NewV3UserPass()
+	service.SetupHTTP(s.Mux)
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "domain")
+	var l Authenticator = &V3UserPass{}
+	creds := Credentials{
+		User:       "joe-user",
+		URL:        s.Server.URL + "/v3/auth/tokens",
+		Secrets:    "secrets",
+		TenantName: "tenant",
+		Domain:     "domain",
+	}
+	auth, err := l.Auth(&creds)
+	c.Assert(err, gc.IsNil)
+	c.Assert(auth.Token, gc.Equals, userInfo.Token)
+	c.Assert(auth.Domain, gc.Equals, "domain")
+}
+
 func (s *V3UserPassTestSuite) TestAuthWithCatalog(c *gc.C) {
 	service := identityservice.NewV3UserPass()
 	service.SetupHTTP(s.Mux)
-	userInfo := service.AddUser("joe-user", "secrets", "tenant")
+	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
 	serviceDef := identityservice.V3Service{
 		Name:      "swift",
 		Type:      "object-store",

--- a/testservices/cmd/main.go
+++ b/testservices/cmd/main.go
@@ -65,7 +65,7 @@ func main() {
 	mux := http.NewServeMux()
 	p.SetupHTTP(mux)
 	for _, u := range users.users {
-		p.AddUser(u.user, u.secret, "tenant")
+		p.AddUser(u.user, u.secret, "tenant", "default")
 	}
 	log.Fatal(http.ListenAndServe(*serveAddr, mux))
 }

--- a/testservices/identityservice/identityservice.go
+++ b/testservices/identityservice/identityservice.go
@@ -4,7 +4,7 @@ import "net/http"
 
 // An IdentityService provides user authentication for an Openstack instance.
 type IdentityService interface {
-	AddUser(user, secret, tenant string) *UserInfo
+	AddUser(user, secret, tenant, authDomain string) *UserInfo
 	FindUser(token string) (*UserInfo, error)
 	RegisterServiceProvider(name, serviceType string, serviceProvider ServiceProvider)
 	AddService(service Service)

--- a/testservices/identityservice/keypair.go
+++ b/testservices/identityservice/keypair.go
@@ -81,7 +81,7 @@ func (u *KeyPair) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	userInfo, errmsg := u.authenticate(req.Auth.ApiAccessKeyCredentials.AccessKey, req.Auth.ApiAccessKeyCredentials.SecretKey)
+	userInfo, errmsg := u.authenticate(req.Auth.ApiAccessKeyCredentials.AccessKey, req.Auth.ApiAccessKeyCredentials.SecretKey, "default")
 	if errmsg != "" {
 		u.ReturnFailure(w, http.StatusUnauthorized, errmsg)
 		return

--- a/testservices/identityservice/keypair_test.go
+++ b/testservices/identityservice/keypair_test.go
@@ -23,7 +23,7 @@ func makeKeyPair(user, secret string) (identity *KeyPair) {
 	// Ensure that it conforms to the interface
 	var _ IdentityService = identity
 	if user != "" {
-		identity.AddUser(user, secret, "tenant")
+		identity.AddUser(user, secret, "tenant", "default")
 	}
 	return
 }
@@ -74,8 +74,8 @@ func (s *KeyPairSuite) TestNotJSON(c *gc.C) {
 	request, err := http.NewRequest("POST", s.Server.URL+"/tokens", body)
 	c.Assert(err, gc.IsNil)
 	res, err := client.Do(request)
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusBadRequest, notJSON)
 }
 
@@ -83,24 +83,24 @@ func (s *KeyPairSuite) TestBadJSON(c *gc.C) {
 	// We do everything in keyPairAuthRequest, except set the Content-Type
 	s.setupKeyPair("user", "secret")
 	res, err := keyPairAuthRequest(s.Server.URL, `garbage"in`, "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusBadRequest, notJSON)
 }
 
 func (s *KeyPairSuite) TestNoSuchUser(c *gc.C) {
 	s.setupKeyPair("user", "secret")
 	res, err := keyPairAuthRequest(s.Server.URL, "not-user", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusUnauthorized, notAuthorized)
 }
 
 func (s *KeyPairSuite) TestBadPassword(c *gc.C) {
 	s.setupKeyPair("user", "secret")
 	res, err := keyPairAuthRequest(s.Server.URL, "user", "not-secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusUnauthorized, invalidUser)
 }
 
@@ -111,8 +111,8 @@ func (s *KeyPairSuite) TestValidAuthorization(c *gc.C) {
 			{PublicURL: compute_url},
 		}}}})
 	res, err := keyPairAuthRequest(s.Server.URL, "user", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	c.Check(res.StatusCode, gc.Equals, http.StatusOK)
 	c.Check(res.Header.Get("Content-Type"), gc.Equals, "application/json")
 	content, err := ioutil.ReadAll(res.Body)

--- a/testservices/identityservice/legacy_test.go
+++ b/testservices/identityservice/legacy_test.go
@@ -23,7 +23,7 @@ func (s *LegacySuite) setupLegacy(user, secret string) (token, managementURL str
 	identity.SetManagementURL(managementURL)
 	identity.SetupHTTP(s.Mux)
 	if user != "" {
-		userInfo := identity.AddUser(user, secret, "tenant")
+		userInfo := identity.AddUser(user, secret, "tenant", "default")
 		token = userInfo.Token
 	}
 	return

--- a/testservices/identityservice/service_test.go
+++ b/testservices/identityservice/service_test.go
@@ -18,7 +18,7 @@ var _ = gc.Suite(&IdentityServiceSuite{service: NewUserPass()})
 var _ = gc.Suite(&IdentityServiceSuite{service: NewLegacy()})
 
 func (s *IdentityServiceSuite) TestAddUserGivesNewToken(c *gc.C) {
-	userInfo1 := s.service.AddUser("user-1", "password-1", "tenant")
-	userInfo2 := s.service.AddUser("user-2", "password-2", "tenant")
+	userInfo1 := s.service.AddUser("user-1", "password-1", "tenant", "default")
+	userInfo2 := s.service.AddUser("user-2", "password-2", "tenant", "default")
 	c.Assert(userInfo1.Token, gc.Not(gc.Equals), userInfo2.Token)
 }

--- a/testservices/identityservice/userpass.go
+++ b/testservices/identityservice/userpass.go
@@ -213,7 +213,7 @@ func (u *UserPass) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	userInfo, errmsg := u.authenticate(req.Auth.PasswordCredentials.Username, req.Auth.PasswordCredentials.Password)
+	userInfo, errmsg := u.authenticate(req.Auth.PasswordCredentials.Username, req.Auth.PasswordCredentials.Password, "default")
 	if errmsg != "" {
 		u.ReturnFailure(w, http.StatusUnauthorized, errmsg)
 		return

--- a/testservices/identityservice/userpass_test.go
+++ b/testservices/identityservice/userpass_test.go
@@ -23,7 +23,7 @@ func makeUserPass(user, secret string) (identity *UserPass) {
 	// Ensure that it conforms to the interface
 	var _ IdentityService = identity
 	if user != "" {
-		identity.AddUser(user, secret, "tenant")
+		identity.AddUser(user, secret, "tenant", "default")
 	}
 	return
 }
@@ -89,8 +89,8 @@ func (s *UserPassSuite) TestNotJSON(c *gc.C) {
 	request, err := http.NewRequest("POST", s.Server.URL+"/tokens", body)
 	c.Assert(err, gc.IsNil)
 	res, err := client.Do(request)
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusBadRequest, notJSON)
 }
 
@@ -98,24 +98,24 @@ func (s *UserPassSuite) TestBadJSON(c *gc.C) {
 	// We do everything in userPassAuthRequest, except set the Content-Type
 	s.setupUserPass("user", "secret")
 	res, err := userPassAuthRequest(s.Server.URL, "garbage\"in", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusBadRequest, notJSON)
 }
 
 func (s *UserPassSuite) TestNoSuchUser(c *gc.C) {
 	s.setupUserPass("user", "secret")
 	res, err := userPassAuthRequest(s.Server.URL, "not-user", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusUnauthorized, notAuthorized)
 }
 
 func (s *UserPassSuite) TestBadPassword(c *gc.C) {
 	s.setupUserPass("user", "secret")
 	res, err := userPassAuthRequest(s.Server.URL, "user", "not-secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusUnauthorized, invalidUser)
 }
 
@@ -126,8 +126,8 @@ func (s *UserPassSuite) TestValidAuthorization(c *gc.C) {
 			{PublicURL: compute_url},
 		}}}})
 	res, err := userPassAuthRequest(s.Server.URL, "user", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	c.Check(res.StatusCode, gc.Equals, http.StatusOK)
 	c.Check(res.Header.Get("Content-Type"), gc.Equals, "application/json")
 	content, err := ioutil.ReadAll(res.Body)

--- a/testservices/identityservice/util.go
+++ b/testservices/identityservice/util.go
@@ -8,10 +8,11 @@ import (
 )
 
 type UserInfo struct {
-	Id       string
-	TenantId string
-	Token    string
-	secret   string
+	Id         string
+	TenantId   string
+	Token      string
+	secret     string
+	authDomain string
 }
 
 var randReader = rand.Reader

--- a/testservices/identityservice/v3userpass_test.go
+++ b/testservices/identityservice/v3userpass_test.go
@@ -23,7 +23,7 @@ func makeV3UserPass(user, secret string) (identity *V3UserPass) {
 	// Ensure that it conforms to the interface
 	var _ IdentityService = identity
 	if user != "" {
-		identity.AddUser(user, secret, "tenant")
+		identity.AddUser(user, secret, "tenant", "default")
 	}
 	return
 }
@@ -81,8 +81,8 @@ func (s *V3UserPassSuite) TestNotJSON(c *gc.C) {
 	request, err := http.NewRequest("POST", s.Server.URL+"/v3/auth/tokens", body)
 	c.Assert(err, gc.IsNil)
 	res, err := client.Do(request)
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusBadRequest, notJSON)
 }
 
@@ -90,24 +90,24 @@ func (s *V3UserPassSuite) TestBadJSON(c *gc.C) {
 	// We do everything in userPassAuthRequest, except set the Content-Type
 	s.setupUserPass("user", "secret")
 	res, err := v3UserPassAuthRequest(s.Server.URL, "garbage\"in", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusBadRequest, notJSON)
 }
 
 func (s *V3UserPassSuite) TestNoSuchUser(c *gc.C) {
 	s.setupUserPass("user", "secret")
 	res, err := v3UserPassAuthRequest(s.Server.URL, "not-user", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusUnauthorized, notAuthorized)
 }
 
 func (s *V3UserPassSuite) TestBadPassword(c *gc.C) {
 	s.setupUserPass("user", "secret")
 	res, err := v3UserPassAuthRequest(s.Server.URL, "user", "not-secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	CheckErrorResponse(c, res, http.StatusUnauthorized, invalidUser)
 }
 
@@ -116,8 +116,8 @@ func (s *V3UserPassSuite) TestValidAuthorization(c *gc.C) {
 	s.setupUserPassWithServices("user", "secret", []Service{
 		{V3: V3Service{Name: "nova", Type: "compute", Endpoints: NewV3Endpoints("", "", compute_url, "")}}})
 	res, err := v3UserPassAuthRequest(s.Server.URL, "user", "secret")
-	defer res.Body.Close()
 	c.Assert(err, gc.IsNil)
+	defer res.Body.Close()
 	c.Check(res.StatusCode, gc.Equals, http.StatusCreated)
 	c.Check(res.Header.Get("Content-Type"), gc.Equals, "application/json")
 	content, err := ioutil.ReadAll(res.Body)

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -322,21 +322,21 @@ func (n *NeutronModel) AddSecurityGroupRule(ruleId string, rule neutron.RuleInfo
 		newrule.IPProtocol = &rule.IPProtocol
 	}
 	switch rule.EthernetType {
-		case "":
-			// Neutron assumes IPv4 if no EthernetType is specified
-			newrule.EthernetType = "IPv4"
-		case "IPv4", "IPv6":
-			newrule.EthernetType = rule.EthernetType
-		default:
-			return testservices.NewSecurityGroupRuleInvalidEthernetType(rule.EthernetType)
+	case "":
+		// Neutron assumes IPv4 if no EthernetType is specified
+		newrule.EthernetType = "IPv4"
+	case "IPv4", "IPv6":
+		newrule.EthernetType = rule.EthernetType
+	default:
+		return testservices.NewSecurityGroupRuleInvalidEthernetType(rule.EthernetType)
 	}
-	if (newrule.RemoteIPPrefix != "") {
+	if newrule.RemoteIPPrefix != "" {
 		ip, _, err := net.ParseCIDR(newrule.RemoteIPPrefix)
-		if (err != nil) {
+		if err != nil {
 			return testservices.NewSecurityGroupRuleInvalidCIDR(rule.RemoteIPPrefix)
 		}
-		if ((newrule.EthernetType == "IPv4" && ip.To4() == nil) ||
-		    (newrule.EthernetType == "IPv6" && ip.To4() != nil)) {
+		if (newrule.EthernetType == "IPv4" && ip.To4() == nil) ||
+			(newrule.EthernetType == "IPv6" && ip.To4() != nil) {
 			return testservices.NewSecurityGroupRuleParameterConflict("ethertype", newrule.EthernetType, "CIDR", newrule.RemoteIPPrefix)
 		}
 	}

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -478,7 +478,7 @@ func (n *Neutron) handleSecurityGroupRules(w http.ResponseWriter, r *http.Reques
 		// set default EthernetType for correct comparison
 		// TODO: we should probably have a neutronmodel func to parse and set default values
 		//       and/or move the duplicate check there
-		if (inrule.EthernetType == "") {
+		if inrule.EthernetType == "" {
 			inrule.EthernetType = "IPv4"
 		}
 		group, err := n.securityGroup(inrule.ParentGroupId)

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -38,7 +38,7 @@ var _ = gc.Suite(&NeutronHTTPSSuite{HTTPSuite: httpsuite.HTTPSuite{UseTLS: true}
 func (s *NeutronHTTPSuite) SetUpSuite(c *gc.C) {
 	s.HTTPSuite.SetUpSuite(c)
 	identityDouble := identityservice.NewUserPass()
-	userInfo := identityDouble.AddUser("fred", "secret", "tenant")
+	userInfo := identityDouble.AddUser("fred", "secret", "tenant", "default")
 	s.token = userInfo.Token
 	s.service = New(s.Server.URL, versionPath, userInfo.TenantId, region, identityDouble, nil)
 	s.service.AddNeutronModel(neutronmodel.New())
@@ -797,7 +797,7 @@ func (s *NeutronHTTPSuite) TestGetSubnets(c *gc.C) {
 func (s *NeutronHTTPSSuite) SetUpSuite(c *gc.C) {
 	s.HTTPSuite.SetUpSuite(c)
 	identityDouble := identityservice.NewUserPass()
-	userInfo := identityDouble.AddUser("fred", "secret", "tenant")
+	userInfo := identityDouble.AddUser("fred", "secret", "tenant", "default")
 	s.token = userInfo.Token
 	c.Assert(s.Server.URL[:8], gc.Equals, "https://")
 	s.service = New(s.Server.URL, versionPath, userInfo.TenantId, region, identityDouble, nil)

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -42,7 +42,7 @@ var _ = gc.Suite(&NovaHTTPSSuite{HTTPSuite: httpsuite.HTTPSuite{UseTLS: true}, u
 func (s *NovaHTTPSuite) SetUpSuite(c *gc.C) {
 	s.HTTPSuite.SetUpSuite(c)
 	identityDouble := identityservice.NewUserPass()
-	userInfo := identityDouble.AddUser("fred", "secret", "tenant")
+	userInfo := identityDouble.AddUser("fred", "secret", "tenant", "default")
 	s.token = userInfo.Token
 	s.service = New(s.Server.URL, versionPath, userInfo.TenantId, region, identityDouble, nil)
 	if s.useNeutronNetworking {
@@ -1304,7 +1304,7 @@ func (s *NovaHTTPSuite) TestListAvailabilityZones(c *gc.C) {
 func (s *NovaHTTPSSuite) SetUpSuite(c *gc.C) {
 	s.HTTPSuite.SetUpSuite(c)
 	identityDouble := identityservice.NewUserPass()
-	userInfo := identityDouble.AddUser("fred", "secret", "tenant")
+	userInfo := identityDouble.AddUser("fred", "secret", "tenant", "default")
 	s.token = userInfo.Token
 	c.Assert(s.Server.URL[:8], gc.Equals, "https://")
 	s.service = New(s.Server.URL, versionPath, userInfo.TenantId, region, identityDouble, nil)

--- a/testservices/swiftservice/service_http_test.go
+++ b/testservices/swiftservice/service_http_test.go
@@ -36,7 +36,7 @@ func (s *SwiftHTTPSuite) SetUpSuite(c *gc.C) {
 	s.HTTPSuite.SetUpSuite(c)
 	identityDouble := identityservice.NewUserPass()
 	s.service = New(s.Server.URL, versionPath, tenantId, region, identityDouble, nil)
-	userInfo := identityDouble.AddUser("fred", "secret", "tenant")
+	userInfo := identityDouble.AddUser("fred", "secret", "tenant", "default")
 	s.token = userInfo.Token
 }
 
@@ -366,7 +366,7 @@ func (s *SwiftHTTPSuite) TestUnauthorizedFails(c *gc.C) {
 func (s *SwiftHTTPSSuite) SetUpSuite(c *gc.C) {
 	s.HTTPSuite.SetUpSuite(c)
 	identityDouble := identityservice.NewUserPass()
-	userInfo := identityDouble.AddUser("fred", "secret", "tenant")
+	userInfo := identityDouble.AddUser("fred", "secret", "tenant", "default")
 	s.token = userInfo.Token
 	c.Assert(s.Server.URL[:8], gc.Equals, "https://")
 	s.service = New(s.Server.URL, versionPath, userInfo.TenantId, region, identityDouble, nil)


### PR DESCRIPTION
The bulk of this PR is test changes. It adds support for handling user and project domains when authenticating using keystone v3. Extra credential attributes are used to store the new domain fields.

The auth request is formed by using the non-empty domain attributes in the credential.
Relevant doc http://developer.openstack.org/api-ref/identity/v3/index.html

QA bootstrapped a live customer Mitaka deployment which was previously not working

Fixes: https://bugs.launchpad.net/goose/+bug/1543262