### PR TITLE
Fix for Bug 38: Adding optional filter to Neutron ListNetworksV2()

### DIFF
--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -108,6 +108,26 @@ func (s *LiveTests) TestListNetworksV2(c *gc.C) {
 	c.Check(foundNetwork.Name, gc.Equals, firstNetwork.Name)
 }
 
+func (s *LiveTests) TestListNetworksV2WithFilters(c *gc.C) {
+	filter := neutron.NewFilter()
+	filter.Set(neutron.FilterRouterExternal, "true")
+	networks, err := s.neutron.ListNetworksV2(filter)
+	c.Assert(err, gc.IsNil)
+	if len(networks) < 1 {
+		c.Errorf("at least one neutron network is necessary for this tests")
+	}
+	for _, network := range networks {
+		c.Check(network.Id, gc.Not(gc.Equals), "")
+		c.Check(network.Name, gc.Not(gc.Equals), "")
+		c.Check(network.External, gc.Equals, true)
+	}
+	firstNetwork := networks[0]
+	foundNetwork, err := s.neutron.GetNetworkV2(firstNetwork.Id)
+	c.Assert(err, gc.IsNil)
+	c.Check(foundNetwork.Id, gc.Equals, firstNetwork.Id)
+	c.Check(foundNetwork.Name, gc.Equals, firstNetwork.Name)
+}
+
 func (s *LiveTests) TestSubnetsV2(c *gc.C) {
 	subnets, err := s.neutron.ListSubnetsV2()
 	c.Assert(err, gc.IsNil)

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -631,7 +631,18 @@ func (n *Neutron) handleNetworks(w http.ResponseWriter, r *http.Request) error {
 			}{*network}
 			return sendJSON(http.StatusOK, resp, w, r)
 		}
-		nets := n.allNetworks()
+		f := make(filter)
+		if err := r.ParseForm(); err == nil && len(r.Form) > 0 {
+			for filterKey, filterValues := range r.Form {
+				for _, value := range filterValues {
+					f[filterKey] = value
+				}
+			}
+		}
+		nets, err := n.allNetworks(f)
+		if err != nil {
+			return err
+		}
 		if len(nets) == 0 {
 			nets = []neutron.NetworkV2{}
 		}

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -750,7 +750,8 @@ func (s *NeutronHTTPSuite) TestDeleteFloatingIP(c *gc.C) {
 
 func (s *NeutronHTTPSuite) TestGetNetworks(c *gc.C) {
 	// There are always 4 networks
-	networks := s.service.allNetworks()
+	networks, err := s.service.allNetworks(nil)
+	c.Assert(err, gc.IsNil)
 	c.Assert(networks, gc.HasLen, 4)
 	var expected struct {
 		Networks []neutron.NetworkV2 `json:"networks"`


### PR DESCRIPTION
Filter for Router:External and Name available currently.  There should be no impact to current
ListNetworksV2() calls.