### PR TITLE
goose.v1 to goose.v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,31 @@ goose
 
 Go OpenStack Exchange (goose) - Go bindings for talking to OpenStack.
 
-[![GoDoc](https://godoc.org/gopkg.in/goose.v1?status.png)](http://godoc.org/gopkg.in/goose.v1)
+[![GoDoc](https://godoc.org/gopkg.in/goose.v2?status.png)](http://godoc.org/gopkg.in/goose.v2)
 
-**NOTE**: This is a stable branch, which is compatible with the original goose source from [Launchpad](https://launchpad.net/goose/trunk), except for the changed import paths.
+**NOTE**: This is an experimental branch, which is under development with no guarentee of backwards compatibilty at this time (April 2017).  Please use goose.v1 if you require a stable branch.
 
 Instructions
 ------------
 
 Install the package with:
 
-    go get gopkg.in/goose.v1/...
+    go get gopkg.in/goose.v2/...
 
 Import it with:
 
-    import "gopkg.in/goose.v1/<package>"
+    import "gopkg.in/goose.v2/<package>"
 
 Example:
 
-    import "gopkg.in/goose.v1/client"
+    import "gopkg.in/goose.v2/client"
 
 and use _client_ as the package name inside the code.
 The same applies to the other sub-packages: _nova_, _switft_, etc.
 
 For more details, check the API documentation:
 
-* https://gopkg.in/goose.v1
+* https://gopkg.in/goose.v2
 
 Contacts
 --------

--- a/cinder/live_test.go
+++ b/cinder/live_test.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	gc "gopkg.in/check.v1"
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
 )
 
 var _ = gc.Suite(&liveCinderSuite{})

--- a/client/apiversion.go
+++ b/client/apiversion.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
-	gooseerrors "gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
-	"gopkg.in/goose.v1/logging"
+	gooseerrors "gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
+	"gopkg.in/goose.v2/logging"
 )
 
 type apiVersion struct {

--- a/client/client.go
+++ b/client/client.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 	"time"
 
-	gooseerrors "gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/logging"
-	goosesync "gopkg.in/goose.v1/sync"
+	gooseerrors "gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/logging"
+	goosesync "gopkg.in/goose.v2/sync"
 )
 
 const (

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack (Canonistack) tests")

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"time"
 
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/identity"
 )
 
 type AuthCleanup func()

--- a/client/live_test.go
+++ b/client/live_test.go
@@ -3,8 +3,8 @@ package client_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
 )
 
 func registerOpenStackTests(cred *identity.Credentials, authModes []identity.AuthMode) {

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -12,15 +12,15 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/logging"
-	"gopkg.in/goose.v1/swift"
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/openstackservice"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/logging"
+	"gopkg.in/goose.v2/swift"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/openstackservice"
 )
 
 func registerLocalTests(authModes []identity.AuthMode) {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/errors"
+	"gopkg.in/goose.v2/errors"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }

--- a/glance/glance.go
+++ b/glance/glance.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 // API URL parts.

--- a/glance/glance_test.go
+++ b/glance/glance_test.go
@@ -6,9 +6,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/glance"
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/glance"
+	"gopkg.in/goose.v2/identity"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }

--- a/http/client.go
+++ b/http/client.go
@@ -16,9 +16,9 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/goose.v1"
-	"gopkg.in/goose.v1/errors"
-	"gopkg.in/goose.v1/logging"
+	"gopkg.in/goose.v2"
+	"gopkg.in/goose.v2/errors"
+	"gopkg.in/goose.v2/logging"
 )
 
 const (

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
+	"gopkg.in/goose.v2/testing/httpsuite"
 )
 
 func Test(t *testing.T) {

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"strings"
 
-	goosehttp "gopkg.in/goose.v1/http"
-	"gopkg.in/goose.v1/logging"
+	goosehttp "gopkg.in/goose.v2/http"
+	"gopkg.in/goose.v2/logging"
 )
 
 // AuthMode defines the authentication method to use (see Auth*

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -5,8 +5,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	goosehttp "gopkg.in/goose.v1/http"
-	"gopkg.in/goose.v1/testing/envsuite"
+	goosehttp "gopkg.in/goose.v2/http"
+	"gopkg.in/goose.v2/testing/envsuite"
 )
 
 type CredentialsTestSuite struct {

--- a/identity/keypair.go
+++ b/identity/keypair.go
@@ -1,7 +1,7 @@
 package identity
 
 import (
-	goosehttp "gopkg.in/goose.v1/http"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 // KeyPair allows OpenStack cloud authentication using an access and

--- a/identity/keystone.go
+++ b/identity/keystone.go
@@ -3,7 +3,7 @@ package identity
 import (
 	"fmt"
 
-	goosehttp "gopkg.in/goose.v1/http"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 type endpoint struct {

--- a/identity/legacy.go
+++ b/identity/legacy.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	goosehttp "gopkg.in/goose.v1/http"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 type Legacy struct {

--- a/identity/legacy_test.go
+++ b/identity/legacy_test.go
@@ -3,8 +3,8 @@ package identity
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 type LegacyTestSuite struct {

--- a/identity/live_test.go
+++ b/identity/live_test.go
@@ -5,8 +5,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
 )
 
 func registerOpenStackTests(cred *identity.Credentials, authMode identity.AuthMode) {

--- a/identity/local_test.go
+++ b/identity/local_test.go
@@ -6,8 +6,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/testservices/openstackservice"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/testservices/openstackservice"
 )
 
 func registerLocalTests(authMode identity.AuthMode) {

--- a/identity/setup_test.go
+++ b/identity/setup_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack (Canonistack) tests")

--- a/identity/userpass.go
+++ b/identity/userpass.go
@@ -1,7 +1,7 @@
 package identity
 
 import (
-	goosehttp "gopkg.in/goose.v1/http"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 type passwordCredentials struct {

--- a/identity/userpass_test.go
+++ b/identity/userpass_test.go
@@ -3,8 +3,8 @@ package identity
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 type UserPassTestSuite struct {

--- a/identity/v3userpass.go
+++ b/identity/v3userpass.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	goosehttp "gopkg.in/goose.v1/http"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 // v3AuthWrapper wraps the v3AuthRequest to perform v3 authentication.

--- a/identity/v3userpass_test.go
+++ b/identity/v3userpass_test.go
@@ -3,8 +3,8 @@ package identity
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 type V3UserPassTestSuite struct {

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -4,9 +4,9 @@ import (
 	gc "gopkg.in/check.v1"
 	"net"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/neutron"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/neutron"
 )
 
 func registerOpenStackTests(cred *identity.Credentials) {

--- a/neutron/local_test.go
+++ b/neutron/local_test.go
@@ -5,12 +5,12 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/neutron"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/hook"
-	"gopkg.in/goose.v1/testservices/openstackservice"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/neutron"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/openstackservice"
 )
 
 func registerLocalTests() {

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -6,9 +6,9 @@ package neutron
 
 import (
 	"fmt"
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
 	"net/http"
 	"net/url"
 )
@@ -24,8 +24,8 @@ const (
 // Filter keys for Networks.
 // As of the Newton release of OpenStack, Network filter by subnet was not implemented
 const (
-	FilterRouterExternal    = "router:external"    // The router:external
-	FilterNetwork           = "name"               // The network name.
+	FilterRouterExternal = "router:external" // The router:external
+	FilterNetwork        = "name"            // The network name.
 )
 
 // NetworkV2 contains details about a labeled network

--- a/neutron/neutron_test.go
+++ b/neutron/neutron_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack tests")

--- a/nova/json_test.go
+++ b/nova/json_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/nova"
+	"gopkg.in/goose.v2/nova"
 )
 
 type JsonSuite struct {

--- a/nova/live_test.go
+++ b/nova/live_test.go
@@ -9,10 +9,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/nova"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/nova"
 )
 
 const (

--- a/nova/local_test.go
+++ b/nova/local_test.go
@@ -9,15 +9,15 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/hook"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/openstackservice"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/openstackservice"
 )
 
 func registerLocalTests() {

--- a/nova/networks.go
+++ b/nova/networks.go
@@ -9,9 +9,9 @@
 package nova
 
 import (
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 const (

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"reflect"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 // API URL parts.

--- a/nova/nova_test.go
+++ b/nova/nova_test.go
@@ -7,7 +7,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/identity"
 )
 
 // imageDetails specify parameters used to start a test machine for the live tests.

--- a/swift/live_test.go
+++ b/swift/live_test.go
@@ -10,10 +10,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/swift"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/swift"
 )
 
 func registerOpenStackTests(cred *identity.Credentials) {

--- a/swift/local_test.go
+++ b/swift/local_test.go
@@ -3,9 +3,9 @@ package swift_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/openstackservice"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/openstackservice"
 )
 
 func registerLocalTests() {

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -12,9 +12,9 @@ import (
 	"net/url"
 	"time"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/errors"
-	goosehttp "gopkg.in/goose.v1/http"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/errors"
+	goosehttp "gopkg.in/goose.v2/http"
 )
 
 // Client provides a means to access the OpenStack Object Storage Service.

--- a/swift/swift_test.go
+++ b/swift/swift_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/identity"
+	"gopkg.in/goose.v2/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack (Canonistack) tests")

--- a/test.py
+++ b/test.py
@@ -106,9 +106,9 @@ def setup_gopath():
     pwd = os.getcwd()
     if sys.platform == 'win32':
         pwd = pwd.replace('\\', '/')
-    offset = pwd.rfind('src/gopkg.in/goose.v1')
+    offset = pwd.rfind('src/gopkg.in/goose.v2')
     if offset == -1:
-        sys.stderr.write('Could not find "src/gopkg.in/goose.v1" in cwd: %s\n'
+        sys.stderr.write('Could not find "src/gopkg.in/goose.v2" in cwd: %s\n'
                          % (pwd,))
         sys.stderr.write('Unable to automatically set GOPATH\n')
         return

--- a/testservices/cmd/main.go
+++ b/testservices/cmd/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/gnuflag"
 
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 type userInfo struct {

--- a/testservices/identityservice/keypair.go
+++ b/testservices/identityservice/keypair.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"gopkg.in/goose.v1/testservices/hook"
+	"gopkg.in/goose.v2/testservices/hook"
 )
 
 // Implement the v2 Key Pair form of identity based on Keystone

--- a/testservices/identityservice/keypair_test.go
+++ b/testservices/identityservice/keypair_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
+	"gopkg.in/goose.v2/testing/httpsuite"
 )
 
 type KeyPairSuite struct {

--- a/testservices/identityservice/legacy_test.go
+++ b/testservices/identityservice/legacy_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
+	"gopkg.in/goose.v2/testing/httpsuite"
 )
 
 type LegacySuite struct {

--- a/testservices/identityservice/service_test.go
+++ b/testservices/identityservice/service_test.go
@@ -3,7 +3,7 @@ package identityservice
 import (
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
+	"gopkg.in/goose.v2/testing/httpsuite"
 )
 
 // All tests in the IdentityServiceSuite run against each IdentityService

--- a/testservices/identityservice/userpass.go
+++ b/testservices/identityservice/userpass.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"gopkg.in/goose.v1/testservices/hook"
+	"gopkg.in/goose.v2/testservices/hook"
 )
 
 // Implement the v2 User Pass form of identity (Keystone)

--- a/testservices/identityservice/userpass_test.go
+++ b/testservices/identityservice/userpass_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
+	"gopkg.in/goose.v2/testing/httpsuite"
 )
 
 type UserPassSuite struct {

--- a/testservices/identityservice/v3userpass.go
+++ b/testservices/identityservice/v3userpass.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"gopkg.in/goose.v1/testservices/hook"
+	"gopkg.in/goose.v2/testservices/hook"
 )
 
 // V3UserPassRequest Implement the v3 User Pass form of identity (Keystone)

--- a/testservices/identityservice/v3userpass_test.go
+++ b/testservices/identityservice/v3userpass_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/testing/httpsuite"
+	"gopkg.in/goose.v2/testing/httpsuite"
 )
 
 type V3UserPassSuite struct {

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"sync"
 
-	"gopkg.in/goose.v1/neutron"
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testservices"
+	"gopkg.in/goose.v2/neutron"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testservices"
 )
 
 type NeutronModel struct {

--- a/testservices/neutronservice/service.go
+++ b/testservices/neutronservice/service.go
@@ -8,10 +8,10 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/goose.v1/neutron"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
+	"gopkg.in/goose.v2/neutron"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
 )
 
 var _ testservices.HttpService = (*Neutron)(nil)

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -13,9 +13,9 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/goose.v1/neutron"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/neutron"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 const (

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -13,10 +13,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/neutron"
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
+	"gopkg.in/goose.v2/neutron"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
 )
 
 type NeutronHTTPSuite struct {

--- a/testservices/neutronservice/service_test.go
+++ b/testservices/neutronservice/service_test.go
@@ -7,8 +7,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/neutron"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
+	"gopkg.in/goose.v2/neutron"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
 )
 
 type NeutronSuite struct {

--- a/testservices/neutronservice/setup_test.go
+++ b/testservices/neutronservice/setup_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/neutron"
+	"gopkg.in/goose.v2/neutron"
 )
 
 func Test(t *testing.T) {

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -9,10 +9,10 @@ import (
 	"sort"
 	"strings"
 
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
 )
 
 var _ testservices.HttpService = (*Nova)(nil)

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -15,10 +15,10 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/goose.v1/errors"
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/errors"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 const authToken = "X-Auth-Token"

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -14,11 +14,11 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/hook"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
 )
 
 type NovaHTTPSuite struct {

--- a/testservices/novaservice/service_test.go
+++ b/testservices/novaservice/service_test.go
@@ -7,9 +7,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testservices/hook"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
 )
 
 type NovaSuite struct {

--- a/testservices/novaservice/setup_test.go
+++ b/testservices/novaservice/setup_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/nova"
+	"gopkg.in/goose.v2/nova"
 )
 
 func Test(t *testing.T) {

--- a/testservices/openstackservice/openstack.go
+++ b/testservices/openstackservice/openstack.go
@@ -7,12 +7,12 @@ import (
 	"strconv"
 	"strings"
 
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/testservices/identityservice"
-	"gopkg.in/goose.v1/testservices/neutronmodel"
-	"gopkg.in/goose.v1/testservices/neutronservice"
-	"gopkg.in/goose.v1/testservices/novaservice"
-	"gopkg.in/goose.v1/testservices/swiftservice"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/neutronmodel"
+	"gopkg.in/goose.v2/testservices/neutronservice"
+	"gopkg.in/goose.v2/testservices/novaservice"
+	"gopkg.in/goose.v2/testservices/swiftservice"
 )
 
 // Openstack provides an Openstack service double implementation.

--- a/testservices/service.go
+++ b/testservices/service.go
@@ -3,8 +3,8 @@ package testservices
 import (
 	"net/http"
 
-	"gopkg.in/goose.v1/testservices/hook"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 // An HttpService provides the HTTP API for a service double.

--- a/testservices/swiftservice/service.go
+++ b/testservices/swiftservice/service.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/goose.v1/swift"
-	"gopkg.in/goose.v1/testservices"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/swift"
+	"gopkg.in/goose.v2/testservices"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 type object map[string][]byte

--- a/testservices/swiftservice/service_http_test.go
+++ b/testservices/swiftservice/service_http_test.go
@@ -11,9 +11,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/swift"
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/identityservice"
+	"gopkg.in/goose.v2/swift"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/identityservice"
 )
 
 type SwiftHTTPSuite struct {

--- a/tools/secgroup-delete-all/main.go
+++ b/tools/secgroup-delete-all/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/juju/gnuflag"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/nova"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/nova"
 )
 
 // DeleteAll destroys all security groups except the default

--- a/tools/secgroup-delete-all/main_test.go
+++ b/tools/secgroup-delete-all/main_test.go
@@ -7,12 +7,12 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"gopkg.in/goose.v1/client"
-	"gopkg.in/goose.v1/identity"
-	"gopkg.in/goose.v1/nova"
-	"gopkg.in/goose.v1/testing/httpsuite"
-	"gopkg.in/goose.v1/testservices/hook"
-	"gopkg.in/goose.v1/testservices/openstackservice"
+	"gopkg.in/goose.v2/client"
+	"gopkg.in/goose.v2/identity"
+	"gopkg.in/goose.v2/nova"
+	"gopkg.in/goose.v2/testing/httpsuite"
+	"gopkg.in/goose.v2/testservices/hook"
+	"gopkg.in/goose.v2/testservices/openstackservice"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
Change imports from goose.v1 to goose.v2.  Update test.py, README.md accordingly, including note that goose.v2 is experimental at this time.