### PR TITLE
Fix Bug 23 nova live test:

### DIFF
--- a/nova/local_test.go
+++ b/nova/local_test.go
@@ -66,7 +66,7 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 		TenantName: "tenant",
 	}
 	var logMsg []string
-	s.openstack, logMsg = openstackservice.New(s.cred, identity.AuthUserPass, false)
+	s.openstack, logMsg = openstackservice.NewNoSwift(s.cred, identity.AuthUserPass, false)
 	for _, msg := range logMsg {
 		c.Logf(msg)
 	}
@@ -74,6 +74,7 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 
 	s.testFlavor = "m1.small"
 	s.testImageId = "1"
+	s.testNetwork = "net" // per neutronmodel setup
 	s.LiveTests.SetUpSuite(c)
 }
 
@@ -106,6 +107,7 @@ func (s *localLiveSuite) retryLimitHook(sc hook.ServiceControl) hook.ControlProc
 
 func (s *localLiveSuite) setupClient(c *gc.C, logger *log.Logger) *nova.Client {
 	client := client.NewClient(s.cred, identity.AuthUserPass, logger)
+	client.SetRequiredServiceTypes([]string{"compute"})
 	return nova.New(client)
 }
 

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -224,7 +224,7 @@ type ServerDetail struct {
 	Created string
 
 	Flavor   Entity
-	HostId   string
+	HostId   string `json:"hostId"`
 	Id       string `json:"-"`
 	UUID     string
 	Image    Entity
@@ -317,8 +317,8 @@ type RunServerOpts struct {
 	Name               string              `json:"name"`                        // Required
 	FlavorId           string              `json:"flavorRef"`                   // Required
 	ImageId            string              `json:"imageRef"`                    // Required
-	UserData           []byte              `json:"user_data"`                   // Optional
-	SecurityGroupNames []SecurityGroupName `json:"security_groups"`             // Optional
+	UserData           []byte              `json:"user_data,omitempty"`         // Optional
+	SecurityGroupNames []SecurityGroupName `json:"security_groups,omitempty"`   // Optional
 	Networks           []ServerNetworks    `json:"networks"`                    // Optional
 	AvailabilityZone   string              `json:"availability_zone,omitempty"` // Optional
 	Metadata           map[string]string   `json:"metadata,omitempty"`          // Optional

--- a/nova/nova_test.go
+++ b/nova/nova_test.go
@@ -3,6 +3,7 @@ package nova_test
 import (
 	"flag"
 	"reflect"
+	"strings"
 	"testing"
 
 	gc "gopkg.in/check.v1"
@@ -10,37 +11,39 @@ import (
 	"gopkg.in/goose.v2/identity"
 )
 
-// imageDetails specify parameters used to start a test machine for the live tests.
-type imageDetails struct {
-	flavor  string
-	imageId string
-	vendor  string
+// instanceDetails specify parameters used to start a test machine for the live tests.
+type instanceDetails struct {
+	useNeutronNetworking bool
+	flavor               string
+	imageId              string
+	network              string
+	vendor               string
 }
 
-// Out-of-the-box, we support live testing using Canonistack or HP Cloud.
-var testConstraints = map[string]imageDetails{
+// Out-of-the-box, we support live testing using Canonistack.
+var testConstraints = map[string]instanceDetails{
 	"canonistack": {
 		flavor: "m1.tiny", imageId: "f2ca48ce-30d5-4f1f-9075-12e64510368d"},
-	"hpcloud": {
-		flavor: "standard.xsmall", imageId: "81078"},
 }
 
 var live = flag.Bool("live", false, "Include live OpenStack tests")
+var netType = flag.String("netType", "neutron", "Use Neutron or Nova Networking? Default is Neutron.")
 var vendor = flag.String("vendor", "", "The Openstack vendor to test against")
 var imageId = flag.String("image", "", "The image id for which a test service is to be started")
 var flavor = flag.String("flavor", "", "The flavor of the test service")
+var network = flag.String("network", "", "The uuid private network of the test service")
 
 func Test(t *testing.T) {
 	if *live {
 		// We can either specify a vendor, or imageId and flavor separately.
-		var testImageDetails imageDetails
+		var testDetails instanceDetails
 		if *vendor != "" {
 			var ok bool
-			if testImageDetails, ok = testConstraints[*vendor]; !ok {
+			if testDetails, ok = testConstraints[*vendor]; !ok {
 				keys := reflect.ValueOf(testConstraints).MapKeys()
 				t.Fatalf("Unknown vendor %s. Must be one of %s", *vendor, keys)
 			}
-			testImageDetails.vendor = *vendor
+			testDetails.vendor = *vendor
 		} else {
 			if *imageId == "" {
 				t.Fatalf("Must specify image id to use for test instance, "+
@@ -50,13 +53,25 @@ func Test(t *testing.T) {
 				t.Fatalf("Must specify flavor to use for test instance, "+
 					"eg %s for Canonistack", "-flavor m1.tiny")
 			}
-			testImageDetails = imageDetails{*flavor, *imageId, ""}
+			if *network == "" {
+				t.Fatalf("Must specify network by UUID to use for test instance, "+
+					"eg %s for Canonistack", "-network 4e408154-e71a-4702-a8fd-edb8df1b4e6c")
+			}
+			var useNeutronNetworking bool
+			if strings.ToLower(*netType) == "neutron" {
+				useNeutronNetworking = true
+			} else if strings.ToLower(*netType) == "nova" {
+				useNeutronNetworking = false
+			} else {
+				t.Fatalf("netType must be neutron or nova")
+			}
+			testDetails = instanceDetails{useNeutronNetworking, *flavor, *imageId, *network, ""}
 		}
 		cred, err := identity.CompleteCredentialsFromEnv()
 		if err != nil {
 			t.Fatalf("Error setting up test suite: %s", err.Error())
 		}
-		registerOpenStackTests(cred, testImageDetails)
+		registerOpenStackTests(cred, testDetails)
 	}
 	registerLocalTests()
 	gc.TestingT(t)

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -138,10 +138,10 @@ func New(hostURL, versionPath, tenantId, region string, identityService, fallbac
 		}
 	}
 	// Add a sample default network
-	var netId = "1"
-	novaService.networks[netId] = nova.Network{
-		Id:    netId,
-		Label: "net",
+	var name = "net"
+	novaService.networks[name] = nova.Network{
+		Id:    "1",
+		Label: name,
 		Cidr:  "10.0.0.0/24",
 	}
 	return novaService


### PR DESCRIPTION
* Remove requirement for Swift OpenStack Service
* Add network flag to live config to specify uuid of network for RunServer
* Add netType flag to live config, nova or neutron allowed
* Skip tests which are nova network specific if using neutron during live tests
* Add waitForTestServerToStart so test is run correctly