### PR TITLE
Add PortSecurityEnabled to NetworksV2. 

### DIFF
--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -30,12 +30,13 @@ const (
 
 // NetworkV2 contains details about a labeled network
 type NetworkV2 struct {
-	Id                string   `json:"id"` // UUID of the resource
-	Name              string   // User-provided name for the network range
-	SubnetIds         []string `json:"subnets"`         // an array of subnet UUIDs
-	External          bool     `json:"router:external"` // is this network connected to an external router
-	AvailabilityZones []string `json:"availability_zones"`
-	TenantId          string   `json:"tenant_id"`
+	Id                  string   `json:"id"` // UUID of the resource
+	Name                string   // User-provided name for the network range
+	SubnetIds           []string `json:"subnets"`         // an array of subnet UUIDs
+	External            bool     `json:"router:external"` // is this network connected to an external router
+	AvailabilityZones   []string `json:"availability_zones"`
+	TenantId            string   `json:"tenant_id"`
+	PortSecurityEnabled *bool    `json:"port_security_enabled"`
 }
 
 // SubnetV2 contains details about a labeled subnet

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -34,18 +34,31 @@ func New() *NeutronModel {
 		{Id: "999", TenantId: "1", Name: "default", Description: "default group"},
 	}
 	// There are no create/delete network/subnet commands, so make a few default
+	t := true
+	f := false
 	defaultNetworks := []neutron.NetworkV2{
 		{ // for use by opentstack provider test
-			Id:        "1",
-			Name:      "net",
-			SubnetIds: []string{"sub-net"},
-			External:  false,
+			Id:                  "1",
+			Name:                "net",
+			SubnetIds:           []string{"sub-net"},
+			External:            false,
+			AvailabilityZones:   []string{"nova"},
+			PortSecurityEnabled: &t,
+		},
+		{ // for use by opentstack provider test
+			Id:                  "2",
+			Name:                "net-disabled",
+			SubnetIds:           []string{"sub-net2"},
+			External:            false,
+			AvailabilityZones:   []string{"nova"},
+			PortSecurityEnabled: &f,
 		},
 		{
-			Id:        "999",
-			Name:      "private_999",
-			SubnetIds: []string{"999-01"},
-			External:  false,
+			Id:                "999",
+			Name:              "private_999",
+			SubnetIds:         []string{"999-01"},
+			External:          false,
+			AvailabilityZones: []string{"test-available"},
 		},
 		{
 			Id:                "998",

--- a/testservices/neutronservice/service.go
+++ b/testservices/neutronservice/service.go
@@ -4,7 +4,6 @@ package neutronservice
 
 import (
 	"net/url"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -297,14 +296,10 @@ func (n *Neutron) matchNetworks(f filter) ([]neutron.NetworkV2, error) {
 		}
 		networks = matched
 	}
-	if nameRegExp := f[neutron.FilterNetwork]; nameRegExp != "" {
+	if name := f[neutron.FilterNetwork]; name != "" {
 		matched := []neutron.NetworkV2{}
-		regExp, err := regexp.Compile(nameRegExp)
-		if err != nil {
-			return nil, err
-		}
 		for _, network := range networks {
-			if regExp.MatchString(network.Name) {
+			if name == network.Name {
 				matched = append(matched, network)
 			}
 		}

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -752,7 +752,7 @@ func (s *NeutronHTTPSuite) TestGetNetworks(c *gc.C) {
 	// There are always 4 networks
 	networks, err := s.service.allNetworks(nil)
 	c.Assert(err, gc.IsNil)
-	c.Assert(networks, gc.HasLen, 4)
+	c.Assert(networks, gc.HasLen, 5)
 	var expected struct {
 		Networks []neutron.NetworkV2 `json:"networks"`
 	}

--- a/testservices/neutronservice/service_test.go
+++ b/testservices/neutronservice/service_test.go
@@ -472,7 +472,7 @@ func (s *NeutronSuite) TestAllNetworksV2WithMultipleFilters(c *gc.C) {
 	}
 	f := filter{
 		neutron.FilterRouterExternal: "true",
-		neutron.FilterNetwork:        "L.*4",
+		neutron.FilterNetwork:        "ListNetwork42",
 	}
 	foundNetworks, err := s.service.allNetworks(f)
 	c.Assert(err, gc.IsNil)
@@ -510,7 +510,7 @@ func (s *NeutronSuite) TestAllNetworksV2WithFilters(c *gc.C) {
 		}
 	}
 	f = filter{
-		neutron.FilterNetwork: "L.*7$",
+		neutron.FilterNetwork: "ListNetwork7",
 	}
 	foundNetworks, err = s.service.allNetworks(f)
 	c.Assert(err, gc.IsNil)


### PR DESCRIPTION
... Update testservices to not add
SecurityGroups if PortSecurityEnabled is false and add server SecurityGroups
to the ServerDetail returned.

NeutronFilter should not be a regexp to match real life behavior.  Update tests accordingly.

This is required to fix juju openstack provider bug: https://bugs.launchpad.net/juju/+bug/1680787.

Tested with test service and with juju against openstack networks with port_security_enabled set to true and false.