### PR TITLE
Add Fault to nova.ServerDetail for details of a nova instance in an E…

### DIFF
--- a/nova/local_test.go
+++ b/nova/local_test.go
@@ -74,7 +74,7 @@ func (s *localLiveSuite) SetUpSuite(c *gc.C) {
 
 	s.testFlavor = "m1.small"
 	s.testImageId = "1"
-	s.testNetwork = "net" // per neutronmodel setup
+	s.testNetwork = "1" // per neutronmodel setup
 	s.LiveTests.SetUpSuite(c)
 }
 

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -206,6 +206,15 @@ type IPAddress struct {
 	Type    string `json:"OS-EXT-IPS:type"` // fixed or floating
 }
 
+// ServerFault describes a single server fault. Details (stack trace) are available for
+// those with adminstrator privilages.
+type ServerFault struct {
+	Code    int    `json:"code"` // Response code
+	Created string `json:"created"`
+	Message string `json:"message"`
+	Details string `json:"details,omitempty"`
+}
+
 // ServerDetail describes a server in more detail.
 // See: http://docs.openstack.org/api/openstack-compute/2/content/Extensions-d1e1444.html#ServersCBSJ
 type ServerDetail struct {
@@ -241,6 +250,9 @@ type ServerDetail struct {
 	// Status holds the current status of the server,
 	// one of the Status* constants.
 	Status string
+
+	// Only returned if status is Error
+	Fault *ServerFault `json:"fault"`
 
 	TenantId string `json:"tenant_id"`
 

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -658,7 +658,7 @@ func (n *Nova) handleRunServer(body []byte, w http.ResponseWriter, r *http.Reque
 		HostId:           "1",
 		Image:            image,
 		Flavor:           flavorEnt,
-		Status:           nova.StatusActive,
+		Status:           nova.StatusBuild,
 		Created:          timestr,
 		Updated:          timestr,
 		Addresses:        make(map[string][]nova.IPAddress),

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -572,6 +572,7 @@ func (s *NovaHTTPSuite) TestGetServers(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusOK)
 	assertJSON(c, resp, &expectedServer)
+	servers[0].Status = nova.StatusActive
 	c.Assert(expectedServer.Server, gc.DeepEquals, servers[0])
 }
 


### PR DESCRIPTION
…RROR state.

Update testservices to allow for 'No valid host' error on specified availability zone.  ServerDetails will now return with server StatusActive, unless StatusError triggered with AZ.

Also tested against a live openstack where one network caused a 'No Valid Host' error.