### PR TITLE
Fix bug lp:1683495, if nova ServerDetail.Image fails to unmarshall as

### DIFF
--- a/client/apiversion_test.go
+++ b/client/apiversion_test.go
@@ -74,7 +74,7 @@ func (s *localLiveSuite) makeServiceURLTests() []makeServiceURLTest {
 			version:     "q2.0",
 			parts:       []string{"foo", "bar/"},
 			success:     false,
-			err:         "strconv.ParseInt: parsing \"q2\": invalid syntax",
+			err:         "strconv.Atoi: parsing \"q2\": invalid syntax",
 		},
 		{
 			serviceType: "object-store",

--- a/nova/json.go
+++ b/nova/json.go
@@ -88,7 +88,16 @@ func (entity *Entity) UnmarshalJSON(b []byte) error {
 	var je jsonEntity = jsonEntity(*entity)
 	var err error
 	if err = json.Unmarshal(b, &je); err != nil {
-		return err
+		// Related Bug lp:1683495, within the openstack compute api
+		// response to List Servers Detailed, the image object might
+		// be an empty string when you boot the server from a volume.
+		// Before failing here, let's check to see if that's the case.
+		if string(b) == "\"\"" {
+			*entity = Entity(je)
+			return nil
+		} else {
+			return err
+		}
 	}
 	if je.Id, err = getIdAsString(b, idTag); err != nil {
 		return err

--- a/nova/json_test.go
+++ b/nova/json_test.go
@@ -81,3 +81,14 @@ func (s *JsonSuite) TestUnmarshallRuleInfoNilStrings(c *gc.C) {
 	}
 	c.Assert(ri, gc.DeepEquals, expected)
 }
+
+func (s *JsonSuite) TestUnmarshallServerDetailImage(c *gc.C) {
+	var image nova.Entity
+	data := []byte(`""`)
+	err := json.Unmarshal(data, &image)
+	c.Assert(err, gc.IsNil)
+	expected := nova.Entity{
+		Id: "",
+	}
+	c.Assert(image, gc.DeepEquals, expected)
+}


### PR DESCRIPTION
a nova.Entity, try as a string before failing.  Added related test.