### PR TITLE
http: persistent client connections

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -26,17 +26,6 @@ const (
 	contentTypeOctetStream = "application/octet-stream"
 )
 
-func init() {
-	// See https://code.google.com/p/go/issues/detail?id=4677
-	// We need to force the connection to close each time so that we don't
-	// hit the above Go bug.
-	roundTripper := http.DefaultClient.Transport
-	if transport, ok := roundTripper.(*http.Transport); ok {
-		transport.DisableKeepAlives = true
-	}
-	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
-}
-
 type Client struct {
 	http.Client
 	maxSendAttempts int
@@ -218,6 +207,16 @@ func (c *Client) BinaryRequest(method, url, token string, reqData *RequestData, 
 	if reqData.RespReader != nil {
 		reqData.RespReader = resp.Body
 	} else {
+		if method != "HEAD" && resp.ContentLength != 0 {
+			// Read a small amount of data from the response
+			// body so that the client connection can
+			// be reused.
+			size := resp.ContentLength
+			if size > 1024 || size < 0 {
+				size = 1024
+			}
+			resp.Body.Read(make([]byte, size))
+		}
 		resp.Body.Close()
 	}
 	return

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -5,16 +5,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"testing"
 
 	gc "gopkg.in/check.v1"
 
 	"gopkg.in/goose.v2/testing/httpsuite"
 )
-
-func Test(t *testing.T) {
-	gc.TestingT(t)
-}
 
 type LoopingHTTPSuite struct {
 	httpsuite.HTTPSuite
@@ -42,12 +37,7 @@ type HTTPClientTestSuite struct {
 	LoopingHTTPSuite
 }
 
-type HTTPSClientTestSuite struct {
-	LoopingHTTPSuite
-}
-
 var _ = gc.Suite(&HTTPClientTestSuite{})
-var _ = gc.Suite(&HTTPSClientTestSuite{LoopingHTTPSuite{httpsuite.HTTPSuite{UseTLS: true}}})
 
 func (s *HTTPClientTestSuite) assertHeaderValues(c *gc.C, token string) {
 	emptyHeaders := http.Header{}
@@ -180,9 +170,15 @@ func (s *HTTPClientTestSuite) TestJSONRequestSetsToken(c *gc.C) {
 	c.Check(agent, gc.Equals, "token")
 }
 
-func (s *HTTPClientTestSuite) TestHttpTransport(c *gc.C) {
-	transport := http.DefaultTransport.(*http.Transport)
-	c.Assert(transport.DisableKeepAlives, gc.Equals, true)
+type HTTPSClientTestSuite struct {
+	LoopingHTTPSuite
+}
+
+var _ = gc.Suite(&HTTPSClientTestSuite{})
+
+func (s *HTTPSClientTestSuite) SetUpSuite(c *gc.C) {
+	s.UseTLS = true
+	s.LoopingHTTPSuite.SetUpSuite(c)
 }
 
 func (s *HTTPSClientTestSuite) TestDefaultClientRejectSelfSigned(c *gc.C) {

--- a/http/conn_reuse_test.go
+++ b/http/conn_reuse_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+
+	gc "gopkg.in/check.v1"
+)
+
+type ConnReuseSuite struct {
+}
+
+var _ = gc.Suite(&ConnReuseSuite{})
+
+func (*ConnReuseSuite) TestConnectionsAreReused(c *gc.C) {
+	oldTransport := http.DefaultTransport.(*http.Transport)
+	defer func() {
+		http.DefaultTransport = oldTransport
+	}()
+	transport := *oldTransport
+	connCount := int32(0)
+	transport.DialContext = func(ctx context.Context, net, addr string) (net.Conn, error) {
+		atomic.AddInt32(&connCount, 1)
+		return oldTransport.DialContext(ctx, net, addr)
+	}
+	http.DefaultTransport = &transport
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		switch req.URL.Path {
+		case "/with-body-chunked":
+			w.Header().Set("Test", "0")
+			w.Write([]byte("chunked"))
+		case "/with-body-non-chunked":
+			body := []byte("non-chunked")
+			w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+			w.Header().Set("Test", "1")
+			w.Write(body)
+		case "/no-body":
+			w.Header().Set("Test", "2")
+		case "/large-body":
+			w.Header().Set("Test", "3")
+			w.Write([]byte(strings.Repeat("a", 1025)))
+		default:
+			c.Errorf("unexpected path %s", req.URL.Path)
+		}
+	}))
+	client := New()
+
+	assertReq := func(path string, expectTestHeader string) {
+		var req RequestData
+		err := client.BinaryRequest("GET", srv.URL+path, "", &req, nil)
+		c.Assert(err, gc.Equals, nil)
+		c.Assert(req.RespHeaders.Get("Test"), gc.Equals, expectTestHeader)
+	}
+	for i, path := range []string{
+		"/with-body-chunked",
+		"/with-body-non-chunked",
+		"/no-body",
+	} {
+		assertReq(path, fmt.Sprint(i))
+	}
+	c.Assert(connCount, gc.Equals, int32(1))
+	// When the body is too large, another connection
+	// will be made.
+	assertReq("/large-body", "3")
+	assertReq("/no-body", "2")
+	c.Assert(connCount, gc.Equals, int32(2))
+}

--- a/http/package_test.go
+++ b/http/package_test.go
@@ -1,0 +1,11 @@
+package http
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
Two issues were preventing client connections from being
reused (leading to significant performance reduction):

- we were specifically asking for connections not to be reused,
citing Go issue 4677, which has been fixed since Go 1.6

- Some responses (notably the response to CreateContainer)
were returning response bodies which were not being read.