### PR TITLE
swift: readahead support when reading objects

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -225,7 +225,6 @@ func (c *authenticatingClient) sendAuthRequest(
 	if err = c.Authenticate(); err != nil {
 		return
 	}
-
 	url, err := c.MakeServiceURL(svcType, apiVersion, []string{apiCall})
 	if err != nil {
 		return

--- a/internal/httpfile/httpfile.go
+++ b/internal/httpfile/httpfile.go
@@ -1,0 +1,531 @@
+package httpfile
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// NoSkip holds the maximum number of bytes that we
+// will read instead of discarding a connection in order
+// to seek.
+const NoSkip = 64 * 1024
+
+// unlimited is used as a special case to signify an unlimited number of
+// bytes. We trust that no files are as big as 4 exabytes for now.
+const unlimited = int64(1 << 62)
+
+// Request represents a request made by a File instance.
+// It will usually be mapped into an HTTP request
+// to the object that has been opened.
+type Request struct {
+	Method string
+	Header http.Header
+}
+
+// Response represents a response from a Request.
+// It will usually be created from an HTTP response.
+type Response struct {
+	StatusCode    int
+	Header        http.Header
+	ContentLength int64
+	Body          io.ReadCloser
+}
+
+type Client interface {
+	// Do sends an HTTP request to the file.
+	// The provided header fields are added
+	// to the request, and the given request is
+	// send with the given method (GET or HEAD).
+	Do(req *Request) (*Response, error)
+}
+
+// SupportedResponseStatuses holds the set of HTTP statuses that a
+// response may legimately have.
+var SupportedResponseStatuses = []int{
+	http.StatusOK,
+	http.StatusNotFound,
+	http.StatusPartialContent,
+	http.StatusPreconditionFailed,
+}
+
+var (
+	// ErrNotFound is returned by Open when the file
+	// does not exist.
+	ErrNotFound = errors.New("file not found")
+
+	// errChanged is returned by a readerAhead
+	errChanged = errors.New("file has changed since it was opened")
+
+	// errOutOfRange is returned by readerAhead to signify
+	// that a given read request is out of the range of
+	// available data.
+	errOutOfRange = errors.New("read out of range")
+)
+
+type File struct {
+	client Client
+
+	// length holds the length of the file.
+	// While initializing the file, this is -1
+	// to signify that the length is unknown.
+	length int64
+
+	// etag holds the entity tag of the file, as returned by the
+	// server in the Etag header. Note that this includes the double
+	// quotes around it too.
+	etag string
+
+	// readAhead holds the number of bytes
+	// to request in advance of any Read.
+	readAhead int64
+
+	// pos holds the current seek position of the reader.
+	pos int64
+
+	// reader0 represents the currently running GET request.
+	reader0 *readerAhead
+
+	// reader1 represents the speculative GET request
+	// one block ahead of reader0. This is never
+	// non-nil when reader0 is nil.
+	reader1 *readerAhead
+}
+
+// Open opens a new file that uses the given client to issue read
+// requests. It returns the open file and any HTTP header returned by
+// the initial client request.
+//
+// If the file is not found, it returned ErrNotFound.
+//
+// The readAhead parameter governs the amount of data that will be
+// requested before any Read calls are made. If it's zero, no data will
+// be requested before Read calls are made. If it's -1, unlimited data
+// will be requested; otherwise the given number of bytes will be
+// requested.
+//
+// If readAhead is less than NoSkip and not -1, all HTTP connections
+// will be available for reuse regardless of how Seek is used.
+func Open(c Client, readAhead int64) (*File, http.Header, error) {
+	if readAhead == -1 {
+		readAhead = unlimited
+	}
+	f := &File{
+		client:    c,
+		length:    -1, // Unknown.
+		readAhead: readAhead,
+	}
+	ra := f.newReaderAhead(0, readAhead)
+	if err := ra.wait(); err != nil {
+		if err == errChanged {
+			// OpenStack can return StatusPreconditionFailed
+			// when the container or object does not exist,
+			// so return ErrNotFound in that case.
+			return nil, ra.header, ErrNotFound
+		}
+		return nil, ra.header, err
+	}
+	f.reader0 = ra
+	f.etag = ra.header.Get("Etag")
+	f.length = ra.length
+	return f, ra.header, nil
+}
+
+// Size returns the total size of the file.
+func (f *File) Size() int64 {
+	return f.length
+}
+
+// Read implements io.Reader.Read.
+func (f *File) Read(buf []byte) (int, error) {
+	if f.pos >= f.length {
+		return 0, io.EOF
+	}
+	if f.reader0 == nil {
+		f.reader0 = f.newReaderAhead(f.pos, f.pos+int64(len(buf)))
+	}
+	n, err := f.reader0.readAt(buf, f.pos)
+	f.pos += int64(n)
+	if err != nil && err != errOutOfRange {
+		if err == io.EOF {
+			return n, io.ErrUnexpectedEOF
+		}
+		return n, err
+	}
+	if err == nil {
+		if f.reader0.remaining() < int64(f.readAhead/2) && f.reader0.p1 < f.length {
+			// We're well advanced through the current reader,
+			// so kick off a new one.
+			f.reader1 = f.newReaderAhead(f.reader0.p1, f.reader0.p1+f.readAhead)
+		}
+		return n, nil
+	}
+
+	// We're trying to read out of range of the current reader, so
+	// throw it away, replace reader0 with reader1 and try
+	// everything again.
+	f.reader0.close()
+	f.reader0, f.reader1 = f.reader1, nil
+	return f.Read(buf)
+}
+
+// Close implements io.Closer.Close. It does not block and never returns
+// an error.
+func (f *File) Close() error {
+	if f.reader0 != nil {
+		f.reader0.close()
+		f.reader0 = nil
+	}
+	if f.reader1 != nil {
+		f.reader1.close()
+		f.reader1 = nil
+	}
+	return nil
+}
+
+// Seek implements io.Seeker.Seek.
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	default:
+		return 0, errors.New("Seek: invalid whence")
+	case io.SeekStart:
+		break
+	case io.SeekCurrent:
+		offset += f.pos
+	case io.SeekEnd:
+		offset += f.length
+	}
+	if offset < 0 {
+		return 0, errors.New("Seek: invalid offset")
+	}
+	f.pos = offset
+	return f.pos, nil
+}
+
+// readerAhead represents an in-progress data request.
+type readerAhead struct {
+	// reqp0 and reqp1 hold the range as
+	// initially requested.
+	reqp0, reqp1 int64
+
+	done chan struct{}
+	// The following fields are filled in with information about the
+	// read request after the response has arrived. These are only
+	// valid to read after the done channel has been closed.
+	r          io.ReadCloser
+	header     http.Header
+	length     int64
+	statusCode int
+	err        error
+	// p0 and p1 hold the actual range received,
+	// which may not be the same as reqp0 and reqp1.
+	p0, p1 int64
+}
+
+// newReaderAhead starts a request to read data
+// in the range [p0, p1). It will constrain the read
+// request if the end of the range is beyond the end
+// of the file.
+//
+// If p1 is unlimited, the request will ask for all
+// of the file from p0 onwards.
+func (f *File) newReaderAhead(p0, p1 int64) *readerAhead {
+	if f.length != -1 {
+		if p1-p0 < f.readAhead {
+			// Never issue a request for less than readAhead bytes
+			p1 = p0 + f.readAhead
+		}
+		if p1 > f.length {
+			// Constrain to end of file.
+			p1 = f.length
+		}
+	}
+	ra := &readerAhead{
+		reqp0: p0,
+		reqp1: p1,
+		done:  make(chan struct{}),
+	}
+	go ra.do(f, f.client, f.newRequest(p0, p1))
+	return ra
+}
+
+// do initiates the client request and updates ra
+// according to the response when it is available.
+func (ra *readerAhead) do(f *File, client Client, req *Request) {
+	defer close(ra.done)
+	resp, err := client.Do(req)
+	if resp != nil {
+		ra.header = resp.Header
+		ra.statusCode = resp.StatusCode
+	}
+	defer func() {
+		if ra.err != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+	if err != nil {
+		ra.err = err
+		return
+	}
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		ra.err = ErrNotFound
+	case http.StatusPreconditionFailed:
+		ra.err = errChanged
+	case http.StatusOK, http.StatusPartialContent:
+		ra.r = resp.Body
+		if err := ra.updateRange(f, resp); err != nil {
+			ra.err = err
+			return
+		}
+		ra.r = resp.Body
+	default:
+		ra.err = fmt.Errorf("unexpected response status %v", resp.StatusCode)
+	}
+}
+
+// updateRange updates ra's range and length from the
+// given response.
+func (ra *readerAhead) updateRange(f *File, resp *Response) error {
+	cr, err := contentRangeFromResponse(resp)
+	if err != nil {
+		return err
+	}
+	if f.length != -1 && cr.length != f.length {
+		return fmt.Errorf("response range has unexpected length; got %d want %d", cr.length, f.length)
+	}
+	// In practice, servers are likely to return exactly the
+	// requested range, but allow some leeway anyway.
+	if cr.p0 > ra.reqp0 || cr.p0 < ra.reqp0-NoSkip {
+		return fmt.Errorf("response range [%d, %d] out of range of requested range starting at %d", cr.p0, cr.p1, ra.reqp0)
+	}
+	ra.p0 = cr.p0
+	ra.p1 = cr.p1
+	ra.length = cr.length
+	return nil
+}
+
+// wait waits for the request to complete and returns
+// any error encountered.
+func (ra *readerAhead) wait() error {
+	<-ra.done
+	return ra.err
+}
+
+// readAt tries to read data into buf at the given offset.
+// It differs from the ioutil.ReaderAt contract in that
+// it does not attempt to read the entire buffer when
+// less data is immediately available.
+func (ra *readerAhead) readAt(buf []byte, p0 int64) (int, error) {
+	// Make an initial check against the requested range, so we
+	// don't bother waiting for the response if we're known to be
+	// out of range.
+	if p0 < ra.reqp0 || p0 >= ra.reqp1 || p0 > ra.reqp0+NoSkip {
+		return 0, errOutOfRange
+	}
+	if err := ra.wait(); err != nil {
+		return 0, err
+	}
+	// Check the actual range, because it may be
+	// different from the request.
+	if p0 < ra.p0 || p0 >= ra.p1 || p0 > ra.p0+NoSkip {
+		return 0, errOutOfRange
+	}
+	if p0 > ra.p0 {
+		// We want to read a relatively short distance ahead of
+		// the current position, so rather than return
+		// errOutOfRange, we read and discard data until we get
+		// to the right point.
+		if err := ra.discard(p0 - ra.p0); err != nil {
+			return 0, err
+		}
+	}
+	n, err := ra.r.Read(buf)
+	if err == io.EOF && n > 0 {
+		// Readers are entitled to return EOF at the end of a
+		// file, even when the read has been fulfilled. In our
+		// case, we only want to return EOF if there really are
+		// no more bytes to be had so suppress the EOF in that
+		// case.
+		err = nil
+	}
+	ra.p0 += int64(n)
+	return n, err
+}
+
+// remaining returns the number of bytes remaining
+// to be read.
+func (ra *readerAhead) remaining() int64 {
+	ra.wait()
+	return ra.p1 - ra.p0
+}
+
+// close closes ra. It does not block.
+func (ra *readerAhead) close() {
+	go func() {
+		ra.wait()
+		if ra.r == nil {
+			return
+		}
+		if ra.remaining() <= NoSkip {
+			// There's not much data left in the section, so
+			// read it so that the HTTP connection can be
+			// reused rather than discarded.
+			ra.discard(ra.remaining())
+		}
+		ra.r.Close()
+	}()
+}
+
+// discard reads and discards n bytes from the reader.
+// It returns io.ErrUnexpectedEOF if all the bytes
+// were not read successfully.
+func (ra *readerAhead) discard(n int64) error {
+	n, err := io.CopyN(ioutil.Discard, ra.r, n)
+	ra.p0 += n
+	if err == io.EOF {
+		return io.ErrUnexpectedEOF
+	}
+	return err
+}
+
+// newRequest returns a new Request to read the data
+// in the interval [p0, p1). If p1 is unlimited, an
+// unlimited amount of data is requested.
+func (f *File) newRequest(p0, p1 int64) *Request {
+	header := make(http.Header)
+	req := &Request{
+		Method: "GET",
+		Header: header,
+	}
+	switch {
+	case p0 == p1:
+		// No bytes requested - no need for a range request.
+		req.Method = "HEAD"
+	case p1 == unlimited && p0 == 0:
+		// We want the whole thing - no need for a range request.
+	case p1 == unlimited:
+		// Indefinite range not starting from the beginning.
+		// This case is here just for completeness - it doesn't
+		// happen in practice.
+		header.Set("Range", fmt.Sprintf("bytes=%d-", p0))
+	default:
+		// Note that the Range header uses a closed interval,
+		// hence the -1.
+		header.Set("Range", fmt.Sprintf("bytes=%d-%d", p0, p1-1))
+	}
+	if f.etag != "" {
+		// Ensure that the read fails if the file has been
+		// written to since we opened it.
+		header.Set("If-Match", f.etag)
+	}
+	return req
+}
+
+// contentRangeFromResponse infers the response content
+// range from the given response.
+func contentRangeFromResponse(resp *Response) (contentRange, error) {
+	if resp.StatusCode == http.StatusOK {
+		// No range - the ContentLength should provide
+		// the length and the range is the whole thing.
+		if cr := resp.Header.Get("Content-Range"); cr != "" {
+			return contentRange{}, fmt.Errorf("received unexpected Content-Range %q in response", cr)
+		}
+		if resp.ContentLength == -1 {
+			return contentRange{}, fmt.Errorf("unknown file length in response")
+		}
+		return contentRange{
+			p0:     0,
+			p1:     resp.ContentLength,
+			length: resp.ContentLength,
+		}, nil
+	}
+	got := resp.Header.Get("Content-Range")
+	if got == "" {
+		return contentRange{}, fmt.Errorf("missing Content-Range in response")
+	}
+	r, ok := parseContentRange(got)
+	if !ok {
+		return contentRange{}, fmt.Errorf("bad Content-Range header %q", got)
+	}
+	return r, nil
+}
+
+// contentRange holds the values in a Content-Range header. The content
+// holds the interval [p0, p1) - note that this corresponds to the usual
+// Go convention of half-open intervals, even though the actual HTTP
+// encoding uses closed intervals.
+type contentRange struct {
+	p0     int64
+	p1     int64
+	length int64
+}
+
+// parseContentRange parses a limited subset of the Content-Range as
+// specified by RFC 7233, section 4.2 and reports whether it has parsed
+// OK.
+//
+// It understands ranges of the form "bytes 42-1233/1234" but not "bytes
+// 42-1233/*" or "*/1234".
+func parseContentRange(s string) (r contentRange, ok bool) {
+	s, ok = trimPrefix(s, "bytes ")
+	if !ok {
+		return contentRange{}, false
+	}
+	r.p0, s, ok = parseInt(s)
+	if !ok {
+		return contentRange{}, false
+	}
+	s, ok = trimPrefix(s, "-")
+	if !ok {
+		return contentRange{}, false
+	}
+	r.p1, s, ok = parseInt(s)
+	if !ok {
+		return contentRange{}, false
+	}
+	// Use the usual Go convention for half-open ranges.
+	r.p1++
+	s, ok = trimPrefix(s, "/")
+	if !ok {
+		return contentRange{}, false
+	}
+	r.length, s, ok = parseInt(s)
+	if !ok {
+		return contentRange{}, false
+	}
+	if s != "" {
+		return contentRange{}, false
+	}
+	if r.p1 <= r.p0 {
+		// Note that HTTP prohibits zero-length ranges.
+		return contentRange{}, false
+	}
+	return r, true
+}
+
+func trimPrefix(s, prefix string) (string, bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return "", false
+	}
+	return s[len(prefix):], true
+}
+
+func parseInt(s string) (int64, string, bool) {
+	end := len(s)
+	for i, c := range s {
+		if c < '0' || c > '9' {
+			end = i
+			break
+		}
+	}
+	n, err := strconv.ParseInt(s[0:end], 10, 64)
+	if err != nil || n < 0 {
+		return 0, "", false
+	}
+	return n, s[end:], true
+}

--- a/internal/httpfile/httpfile_test.go
+++ b/internal/httpfile/httpfile_test.go
@@ -1,0 +1,521 @@
+package httpfile_test
+
+import (
+	"bytes"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	gc "gopkg.in/check.v1"
+	"gopkg.in/goose.v2/internal/httpfile"
+)
+
+type httpFileSuite struct{}
+
+var _ = gc.Suite(&httpFileSuite{})
+
+func (*httpFileSuite) TestNoReadAhead(c *gc.C) {
+	content := newContent(10 * 1024)
+	requestc := make(chan readRequest, 2)
+	srv := httptest.NewServer(&fakeReadServer{
+		content: content,
+		request: requestc,
+	})
+	defer srv.Close()
+
+	// Open the file. Because we've requested zero readahead,
+	// it should just issue a HEAD request.
+	f, h, err := httpfile.Open(&client{
+		c:   c,
+		url: srv.URL + "/file",
+	}, 0)
+	c.Assert(err, gc.Equals, nil)
+	defer f.Close()
+	c.Check(f.Size(), gc.Equals, int64(len(content)))
+	c.Check(h.Get("Etag"), gc.Equals, fmt.Sprintf(`"%x"`, md5.Sum(content)))
+
+	req := getRequest(c, requestc)
+	c.Check(req.Request.URL.Path, gc.Equals, "/file")
+	c.Check(req.doneRead, gc.Equals, false, gc.Commentf("[%d %d]", req.p0, req.p1))
+	c.Check(req.Method, gc.Equals, "HEAD")
+	assertNoRequest(c, requestc)
+
+	off, err := f.Seek(30, io.SeekStart)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(off, gc.Equals, int64(30))
+	assertNoRequest(c, requestc)
+
+	// Issuing a read request causes a single
+	// request to be made to the server.
+	assertReadBytes(c, f, content[30:30+100])
+
+	req = getRequest(c, requestc)
+	c.Check(req.Request.URL.Path, gc.Equals, "/file")
+	c.Check(req.doneRead, gc.Equals, true)
+	c.Check(req.Method, gc.Equals, "GET")
+	c.Check(req.p0, gc.Equals, int64(30))
+	c.Check(req.p1, gc.Equals, int64(130))
+	assertNoRequest(c, requestc)
+
+	// Check that we can seek relative to the end.
+	buf := make([]byte, 200)
+	off, err = f.Seek(-200, io.SeekEnd)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(off, gc.Equals, int64(len(content)-200))
+	assertReadBytes(c, f, content[len(content)-200:])
+
+	req = getRequest(c, requestc)
+	c.Check(req.Request.URL.Path, gc.Equals, "/file")
+	c.Check(req.doneRead, gc.Equals, true)
+	c.Check(req.Method, gc.Equals, "GET")
+	c.Check(req.p0, gc.Equals, int64(len(content)-200))
+	c.Check(req.p1, gc.Equals, int64(len(content)))
+	assertNoRequest(c, requestc)
+
+	// At the end, we should see EOF with no further request
+	// issued.
+	n, err := f.Read(buf)
+	c.Assert(n, gc.Equals, 0)
+	c.Assert(err, gc.Equals, io.EOF)
+	assertNoRequest(c, requestc)
+}
+
+func (*httpFileSuite) TestInfiniteReadAhead(c *gc.C) {
+	content := newContent(10 * 1024)
+	requestc := make(chan readRequest, 2)
+	srv := httptest.NewServer(&fakeReadServer{
+		content: content,
+		request: requestc,
+	})
+	defer srv.Close()
+
+	// Open the file. Because we've requested arbitrary
+	// readahead, it should issue a request to get the
+	// whole file.
+	f, _, err := httpfile.Open(&client{
+		c:   c,
+		url: srv.URL + "/file",
+	}, -1)
+	c.Assert(err, gc.Equals, nil)
+	defer f.Close()
+
+	// Assume the loopback TCP buffer is big enough
+	// to hold all of the content - if it's not, we'd
+	// deadlock here.
+	req := getRequest(c, requestc)
+	c.Check(req.doneRead, gc.Equals, true)
+	c.Check(req.Method, gc.Equals, "GET")
+	c.Check(req.p0, gc.Equals, int64(0))
+	c.Check(req.p1, gc.Equals, int64(len(content)))
+	assertNoRequest(c, requestc)
+
+	data, err := ioutil.ReadAll(f)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(string(data), gc.Equals, string(content))
+	assertNoRequest(c, requestc)
+
+	// Check that we get a single read when seeking back
+	// elsewhere into the content.
+	off, err := f.Seek(30, io.SeekStart)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(off, gc.Equals, int64(30))
+
+	assertReadBytes(c, f, content[30:40])
+	req = getRequest(c, requestc)
+	c.Check(req.doneRead, gc.Equals, true)
+	c.Check(req.Method, gc.Equals, "GET")
+	c.Check(req.p0, gc.Equals, int64(30))
+	c.Check(req.p1, gc.Equals, int64(len(content)))
+	assertNoRequest(c, requestc)
+
+	// Seek ahead a bit and check that it still reuses
+	// the same GET request.
+	off, err = f.Seek(30, io.SeekCurrent)
+	c.Assert(err, gc.Equals, nil)
+	c.Check(off, gc.Equals, int64(70))
+
+	data, err = ioutil.ReadAll(f)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(string(data), gc.Equals, string(content[70:]))
+
+	assertNoRequest(c, requestc)
+}
+
+func (*httpFileSuite) TestLimitedReadAhead(c *gc.C) {
+	content := newContent(10 * 1024)
+	requestc := make(chan readRequest, 2)
+	srv := httptest.NewServer(&fakeReadServer{
+		content: content,
+		request: requestc,
+	})
+	defer srv.Close()
+
+	// Open the file. Because we've requested arbitrary
+	// readahead, it should issue a request to get the
+	// whole file.
+	f, _, err := httpfile.Open(&client{
+		c:   c,
+		url: srv.URL + "/file",
+	}, 200)
+	c.Assert(err, gc.Equals, nil)
+	defer f.Close()
+
+	req := getRequest(c, requestc)
+	c.Check(req.doneRead, gc.Equals, true)
+	c.Check(req.Method, gc.Equals, "GET")
+	c.Check(req.p0, gc.Equals, int64(0))
+	c.Check(req.p1, gc.Equals, int64(200))
+	assertNoRequest(c, requestc)
+
+	// Reading half the readahead amount doesn't
+	// trigger a new request
+	assertReadBytes(c, f, content[0:100])
+	assertNoRequest(c, requestc)
+
+	// Reading past half the readahead amount triggers
+	// a new request.
+	assertReadBytes(c, f, content[100:110])
+
+	req = getRequest(c, requestc)
+	c.Check(req.doneRead, gc.Equals, true)
+	c.Check(req.Method, gc.Equals, "GET")
+	c.Check(req.p0, gc.Equals, int64(200))
+	c.Check(req.p1, gc.Equals, int64(400))
+	assertNoRequest(c, requestc)
+
+	// Reading past the read ahead buffer
+	// results in a partial read ending at that
+	// buffer.
+	buf := make([]byte, 300)
+	n, err := f.Read(buf)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(n, gc.Equals, 90)
+	c.Assert(string(buf[0:90]), gc.Equals, string(content[110:200]))
+
+	// Check we can read all the rest of the content.
+	done := make(chan struct{})
+	go func() {
+		close(done)
+		// Expect one request per readahead block (note
+		// it's rounded up) less the request we've already
+		// seen.
+		for i := 0; i < (len(content)+199)/200-1; i++ {
+			getRequest(c, requestc)
+		}
+		assertNoRequest(c, requestc)
+	}()
+	data, err := ioutil.ReadAll(f)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(string(data), gc.Equals, string(content[200:]))
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for expected requests")
+	}
+}
+
+var badContentRangeResponseTests = []struct {
+	about              string
+	readAhead          int64
+	status             int
+	contentRange       string
+	secondContentRange string
+	expectError        string
+}{{
+	about:        "content range where none expected",
+	readAhead:    -1,
+	status:       http.StatusOK,
+	contentRange: "bytes 0-300/300",
+	expectError:  `received unexpected Content-Range "bytes 0-300/300" in response`,
+}, {
+	about:       "no content length",
+	readAhead:   -1,
+	status:      http.StatusOK,
+	expectError: `unknown file length in response`,
+}, {
+	about:       "no content range",
+	readAhead:   200,
+	status:      http.StatusPartialContent,
+	expectError: `missing Content-Range in response`,
+}, {
+	about:        "content range not starting with bytes",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "100-300",
+	expectError:  `bad Content-Range header "100-300"`,
+}, {
+	about:        "bad start of range",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes foo",
+	expectError:  `bad Content-Range header "bytes foo"`,
+}, {
+	about:        "no hyphen in range",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 0z",
+	expectError:  `bad Content-Range header "bytes 0z"`,
+}, {
+	about:        "bad end of range",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 0-z",
+	expectError:  `bad Content-Range header "bytes 0-z"`,
+}, {
+	about:        "no slash after range",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 0-20z",
+	expectError:  `bad Content-Range header "bytes 0-20z"`,
+}, {
+	about:        "bad content length",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 0-20/z",
+	expectError:  `bad Content-Range header "bytes 0-20/z"`,
+}, {
+	about:        "extra bytes after content length",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 0-20/30z",
+	expectError:  `bad Content-Range header "bytes 0-20/30z"`,
+}, {
+	about:        "out of order range",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 20-19/30",
+	expectError:  `bad Content-Range header "bytes 20-19/30"`,
+}, {
+	about:        "start after requested range",
+	readAhead:    200,
+	status:       http.StatusPartialContent,
+	contentRange: "bytes 1-200/200",
+	expectError:  `response range \[1, 201\] out of range of requested range starting at 0`,
+}, {
+	about:              "wrong length",
+	readAhead:          200,
+	status:             http.StatusPartialContent,
+	contentRange:       "bytes 0-199/4096",
+	secondContentRange: "bytes 200-399/4097",
+	expectError:        `response range has unexpected length; got 4097 want 4096`,
+}}
+
+func (*httpFileSuite) TestBadContentRangeResponse(c *gc.C) {
+	var contentRange string
+	var status int
+	content := newContent(4 * 1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if contentRange != "" {
+			w.Header().Set("Content-Range", contentRange)
+		}
+		w.WriteHeader(status)
+		// Ensure we get chunked encoding when there's
+		// no Content-Length header.
+		w.Write(content)
+	}))
+	defer srv.Close()
+
+	for i, test := range badContentRangeResponseTests {
+		c.Logf("test %d: %v", i, test.about)
+		contentRange = test.contentRange
+		status = test.status
+		f, _, err := httpfile.Open(&client{
+			c:   c,
+			url: srv.URL,
+		}, test.readAhead)
+		if test.secondContentRange == "" {
+			c.Assert(err, gc.ErrorMatches, test.expectError)
+			continue
+		}
+		c.Assert(err, gc.Equals, nil)
+		contentRange = test.secondContentRange
+		// Seek beyond the read-ahead buffer
+		// so that we'll make another read request.
+		f.Seek(test.readAhead, io.SeekStart)
+		buf := make([]byte, 200)
+		_, err = f.Read(buf)
+		c.Assert(err, gc.ErrorMatches, test.expectError)
+		f.Close()
+	}
+}
+
+func (*httpFileSuite) TestFileNotFound(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(http.NotFound))
+	defer srv.Close()
+	_, _, err := httpfile.Open(&client{
+		c:   c,
+		url: srv.URL,
+	}, -1)
+	c.Assert(err, gc.Equals, httpfile.ErrNotFound)
+}
+
+func (*httpFileSuite) TestNotFoundFromPreconditionFailed(c *gc.C) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+	}))
+	defer srv.Close()
+	_, _, err := httpfile.Open(&client{
+		c:   c,
+		url: srv.URL,
+	}, -1)
+	c.Assert(err, gc.Equals, httpfile.ErrNotFound)
+}
+
+func (s *httpFileSuite) TestFileChangedUnderfoot(c *gc.C) {
+	content := newContent(4096)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Etag", fmt.Sprintf(`"%x"`, md5.Sum(content)))
+		http.ServeContent(w, req, "foo.gif", time.Now(), bytes.NewReader(content))
+	}))
+	f, _, err := httpfile.Open(&client{
+		c:   c,
+		url: srv.URL,
+	}, 200)
+	c.Assert(err, gc.Equals, nil)
+
+	_, err = f.Seek(600, io.SeekStart)
+	c.Assert(err, gc.Equals, nil)
+
+	content = newContent(3000)
+	buf := make([]byte, 10)
+	n, err := f.Read(buf)
+	c.Check(err, gc.ErrorMatches, `file has changed since it was opened`)
+	c.Check(n, gc.Equals, 0)
+}
+
+func assertReadBytes(c *gc.C, f io.Reader, expect []byte) {
+	buf := make([]byte, len(expect))
+	n, err := f.Read(buf)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(n, gc.Equals, len(expect))
+	c.Assert(string(buf), gc.Equals, string(expect))
+}
+
+func newContent(size int) []byte {
+	var content []byte
+	for i := 0; len(content) < size; i++ {
+		content = append(content, fmt.Sprint(i, " ")...)
+	}
+	return content[0:size]
+}
+
+type client struct {
+	c   *gc.C
+	url string
+}
+
+func (c *client) Do(req *httpfile.Request) (*httpfile.Response, error) {
+	hreq, _ := http.NewRequest(req.Method, c.url, nil)
+	for key, val := range req.Header {
+		hreq.Header[key] = val
+	}
+	hresp, err := http.DefaultClient.Do(hreq)
+	if err != nil {
+		return nil, err
+	}
+	c.c.Logf("sent request %v %q", req.Method, req.Header)
+	c.c.Logf("-> %v [%d] %q", hresp.StatusCode, hresp.ContentLength, hresp.Header)
+	return &httpfile.Response{
+		StatusCode:    hresp.StatusCode,
+		Header:        hresp.Header,
+		ContentLength: hresp.ContentLength,
+		Body:          hresp.Body,
+	}, nil
+}
+
+func getRequest(c *gc.C, requestc chan readRequest) readRequest {
+	select {
+	case req := <-requestc:
+		return req
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for request")
+		panic("unreachable")
+	}
+}
+
+func assertNoRequest(c *gc.C, requestc chan readRequest) {
+	select {
+	case <-requestc:
+		c.Fatalf("got request when none was expected")
+	case <-time.After(10 * time.Millisecond):
+	}
+}
+
+type readRequest struct {
+	*http.Request
+	doneRead bool
+	p0, p1   int64
+}
+
+type fakeReadServer struct {
+	content []byte
+	request chan readRequest
+}
+
+func (srv *fakeReadServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	rec := newRangeRecorder(bytes.NewReader(srv.content))
+	w.Header().Set("Etag", fmt.Sprintf(`"%x"`, md5.Sum(srv.content)))
+
+	// Use a SectionReader to make a ReadSeeker out of our
+	// rangeRecord (which is a ReaderAt).
+	r := io.NewSectionReader(rec, 0, int64(len(srv.content)))
+	http.ServeContent(w, req, "x.gif", time.Now(), r)
+	select {
+	case srv.request <- readRequest{
+		Request:  req,
+		doneRead: rec.doneRead,
+		p0:       rec.p0,
+		p1:       rec.p1,
+	}:
+	default:
+		panic("cannot send read request")
+	}
+}
+
+// contentRangeServer returns an http.Server that
+// always responds with the given Content-Range header.
+func contentRangeServer(contentRange string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Range", contentRange)
+		w.WriteHeader(http.StatusPartialContent)
+	})
+}
+
+type rangeRecorder struct {
+	r        io.ReaderAt
+	p0, p1   int64
+	doneRead bool
+}
+
+func newRangeRecorder(r io.ReaderAt) *rangeRecorder {
+	return &rangeRecorder{r: r}
+}
+
+// assertRange asserts that the given range of bytes has
+// been read since the last time that assertRange was
+// called or the rangeRecorder was created.
+func (r *rangeRecorder) assertRange(c *gc.C, p0, p1 int64) {
+	if !r.doneRead {
+		c.Fatalf("nothing has been read")
+	}
+	if r.p0 != p0 || r.p1 != p1 {
+		c.Fatalf("unexpected read range; got [%d %d] want [%d %d]", r.p0, r.p1, p0, p1)
+	}
+	r.doneRead = false
+}
+
+func (r *rangeRecorder) ReadAt(buf []byte, p0 int64) (int, error) {
+	p1 := p0 + int64(len(buf))
+	if p0 < r.p0 || !r.doneRead {
+		r.p0 = p0
+	}
+	if p1 > r.p1 || !r.doneRead {
+		r.p1 = p1
+	}
+	r.doneRead = true
+	return r.r.ReadAt(buf, p0)
+}

--- a/internal/httpfile/package_test.go
+++ b/internal/httpfile/package_test.go
@@ -1,0 +1,10 @@
+package httpfile_test
+
+import (
+	gc "gopkg.in/check.v1"
+	"testing"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
We make it more efficient for streaming and seeking
readers by issuing reads ahead of time, meaning we
can be processing some data while the HTTP request
is being read.

Control over the amount of readahead is governed by
the readAhead parameter to the new OpenObject
method, which subsumes GetReadSeeker.