### PR TITLE
To allow for fix of lp:1707248 - Adding filter to ListFloatingIPsV2()

### DIFF
--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -26,6 +26,7 @@ const (
 const (
 	FilterRouterExternal = "router:external" // The router:external
 	FilterNetwork        = "name"            // The network name.
+	FilterProjectId      = "project_id"      // The project id
 )
 
 // NetworkV2 contains details about a labeled network
@@ -160,12 +161,20 @@ type FloatingIPV2 struct {
 }
 
 // ListFloatingIPsV2 lists floating IP addresses associated with the tenant or account.
-func (c *Client) ListFloatingIPsV2() ([]FloatingIPV2, error) {
+// Zero or one Filters accepted, any more will be ignored.
+//
+// TODO(hml): when this package revs to a new version, make this the same as other
+// methods with Filters.  We don't want to break compatibility at this time or rev
+// the package at this time.
+func (c *Client) ListFloatingIPsV2(filter ...*Filter) ([]FloatingIPV2, error) {
 	var resp struct {
 		FloatingIPV2s []FloatingIPV2 `json:"floatingips"`
 	}
-
-	requestData := goosehttp.RequestData{RespValue: &resp}
+	var params *url.Values
+	if len(filter) > 0 {
+		params = &filter[0].v
+	}
+	requestData := goosehttp.RequestData{RespValue: &resp, Params: params}
 	err := c.client.SendRequest(client.GET, "network", "v2.0", ApiFloatingIPsV2, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to list floating ips")

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -66,6 +66,7 @@ func New() *NeutronModel {
 			SubnetIds:         []string{"998-01"},
 			External:          true,
 			AvailabilityZones: []string{"test-available"},
+			TenantId:          "tenant-one",
 		},
 		{
 			Id:                "997",
@@ -73,6 +74,7 @@ func New() *NeutronModel {
 			SubnetIds:         []string{"997-01"},
 			External:          true,
 			AvailabilityZones: []string{"unavailable-az"},
+			TenantId:          "tenant-two",
 		},
 	}
 

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -555,7 +555,15 @@ func (n *Neutron) handleFloatingIPs(w http.ResponseWriter, r *http.Request) erro
 			}{*fip}
 			return sendJSON(http.StatusOK, resp, w, r)
 		}
-		fips := n.allFloatingIPs()
+		f := make(filter)
+		if err := r.ParseForm(); err == nil && len(r.Form) > 0 {
+			for filterKey, filterValues := range r.Form {
+				for _, value := range filterValues {
+					f[filterKey] = value
+				}
+			}
+		}
+		fips := n.allFloatingIPs(f)
 		if len(fips) == 0 {
 			fips = []neutron.FloatingIPV2{}
 		}

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -676,7 +676,7 @@ func (s *NeutronHTTPSuite) TestDeleteSecurityGroupRule(c *gc.C) {
 func (s *NeutronHTTPSuite) TestPostFloatingIPV2(c *gc.C) {
 	// network 998 has External = true
 	fip := neutron.FloatingIPV2{Id: "1", IP: "10.0.0.1", FloatingNetworkId: "998"}
-	c.Assert(s.service.allFloatingIPs(), gc.HasLen, 0)
+	c.Assert(s.service.allFloatingIPs(nil), gc.HasLen, 0)
 	var req struct {
 		IP neutron.FloatingIPV2 `json:"floatingip"`
 	}
@@ -698,7 +698,7 @@ func (s *NeutronHTTPSuite) TestPostFloatingIPV2(c *gc.C) {
 }
 
 func (s *NeutronHTTPSuite) TestGetFloatingIPs(c *gc.C) {
-	c.Assert(s.service.allFloatingIPs(), gc.HasLen, 0)
+	c.Assert(s.service.allFloatingIPs(nil), gc.HasLen, 0)
 	var expected struct {
 		IPs []neutron.FloatingIPV2 `json:"floatingips"`
 	}


### PR DESCRIPTION
Add filter to ListFloatingIPsV2 and neutron.FilterProjectId, so we can get a list of FloatingIPs within the client's project.  Neutron testing and test service updated accordingly.