### PR TITLE
cinder: use goose/http.Client

### DIFF
--- a/nova/local_test.go
+++ b/nova/local_test.go
@@ -317,4 +317,9 @@ func (s *localLiveSuite) TestVolumeAttachments(c *gc.C) {
 	volAttachments, err = s.nova.ListVolumeAttachments(instance.Id)
 	c.Assert(err, gc.IsNil)
 	c.Assert(volAttachments, gc.HasLen, 0)
+
+	// Test detaching unattached volume.
+	err = s.nova.DetachVolume(instance.Id, volAttachment.Id)
+	c.Assert(err, gc.NotNil)
+	c.Assert(errors.IsNotFound(err), gc.Equals, true)
 }

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -798,11 +798,6 @@ func (c *Client) AttachVolume(serverId, volumeId, device string) (*VolumeAttachm
 	}
 	url := fmt.Sprintf("%s/%s/%s", apiServers, serverId, apiVolumeAttachments)
 	err := c.client.SendRequest(client.POST, "compute", "v2", url, &requestData)
-	if errors.IsNotFound(err) {
-		return nil, errors.NewNotImplementedf(
-			err, nil, "the server does not support attaching volumes",
-		)
-	}
 	if err != nil {
 		return nil, errors.Newf(err, "failed to attach volume")
 	}
@@ -817,11 +812,6 @@ func (c *Client) DetachVolume(serverId, attachmentId string) error {
 	}
 	url := fmt.Sprintf("%s/%s/%s/%s", apiServers, serverId, apiVolumeAttachments, attachmentId)
 	err := c.client.SendRequest(client.DELETE, "compute", "v2", url, &requestData)
-	if errors.IsNotFound(err) {
-		return errors.NewNotImplementedf(
-			err, nil, "the server does not support deleting attached volumes",
-		)
-	}
 	if err != nil {
 		return errors.Newf(err, "failed to delete volume attachment")
 	}
@@ -840,11 +830,6 @@ func (c *Client) ListVolumeAttachments(serverId string) ([]VolumeAttachment, err
 	}
 	url := fmt.Sprintf("%s/%s/%s", apiServers, serverId, apiVolumeAttachments)
 	err := c.client.SendRequest(client.GET, "compute", "v2", url, &requestData)
-	if errors.IsNotFound(err) {
-		return nil, errors.NewNotImplementedf(
-			err, nil, "the server does not support listing attached volumes",
-		)
-	}
 	if err != nil {
 		return nil, errors.Newf(err, "failed to list volume attachments")
 	}

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/goose.v2/errors"
 	"gopkg.in/goose.v2/neutron"
 	"gopkg.in/goose.v2/nova"
 	"gopkg.in/goose.v2/testservices"
@@ -1313,7 +1312,8 @@ func (n *Nova) handleDetachVolumes(w http.ResponseWriter, r *http.Request) error
 		}
 	}
 
-	return errors.NewNotFoundf(nil, nil, "no such attachment id: %v", attachId)
+	writeResponse(w, http.StatusNotFound, nil)
+	return nil
 }
 
 func (n *Nova) handleListVolumes(w http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
Use goose/http.Client in a few methods
of the Cinder client, so we can use the
common goose/errors functions. Not all
methods have been updated; only the ones
necessary to delete and detach volumes.

Also update the Nova code for dealing
with volume attachments to not regard
404 as "not implemented".