### PR TITLE
juju bug 1756135, improve handling of service catalog urls 

### DIFF
--- a/client/apiversion.go
+++ b/client/apiversion.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	gooseerrors "gopkg.in/goose.v2/errors"
 	goosehttp "gopkg.in/goose.v2/http"
 	"gopkg.in/goose.v2/logging"
 )
@@ -67,6 +66,14 @@ func getAPIVersionURL(apiURLVersionInfo *apiURLVersion, requested apiVersion) (s
 		return "", fmt.Errorf("could not find matching URL")
 	}
 	versionURL := apiURLVersionInfo.rootURL
+
+	// https://bugs.launchpad.net/juju/+bug/1756135:
+	// some hrefURL.Path contain more than the version, with
+	// overlap on the apiURLVersionInfo.rootURL
+	if strings.HasPrefix(match, "/"+versionURL.Path) {
+		versionURL.Path = "/"
+	}
+
 	versionURL.Path = path.Join(versionURL.Path, match, apiURLVersionInfo.serviceURLSuffix)
 	return versionURL.String(), nil
 }
@@ -141,6 +148,17 @@ func unmarshallVersion(Versions json.RawMessage) ([]apiVersionInfo, error) {
 // in which case this method will return an empty set of versions in the result
 // structure.
 func (c *authenticatingClient) getAPIVersions(serviceCatalogURL string) (*apiURLVersion, error) {
+	c.apiVersionMu.Lock()
+	defer c.apiVersionMu.Unlock()
+	logger := logging.FromCompat(c.logger)
+
+	// Make sure we haven't already received the version info.
+	// Cache done on serviceCatalogURL, https://<url.Host> is not
+	// guarenteed to be unique.
+	if apiInfo, ok := c.apiURLVersions[serviceCatalogURL]; ok {
+		return apiInfo, nil
+	}
+
 	url, err := url.Parse(serviceCatalogURL)
 	if err != nil {
 		return nil, err
@@ -151,24 +169,46 @@ func (c *authenticatingClient) getAPIVersions(serviceCatalogURL string) (*apiURL
 	// API version-specific base URL.
 	var pathParts, origPathParts []string
 	if url.Path != "/" {
-		// The rackspace object-store endpoint triggers the version removal here,
-		// so keep the original parts for object-store and container endpoints.
+		// If a version is included in the serviceCatalogURL, the
+		// part before the version will end up in url, the part after
+		// the version will end up in pathParts.  origPathParts is a
+		// special case for "object-store"
 		// e.g. https://storage101.dfw1.clouddrive.com/v1/MossoCloudFS_1019383
+		// https://x.x.x.x/image
+		// https://x.x.x.x/cloudformation/v1
+		// https://x.x.x.x/compute/v2/9032a0051293421eb20b64da69d46252
+		// http://y.y.y.y:9292
+		// http://y.y.y.y:8774/v2/010ab46135ba414882641f663ec917b6
 		origPathParts = strings.Split(strings.Trim(url.Path, "/"), "/")
 		pathParts = origPathParts
-		if _, err := parseVersion(pathParts[0]); err == nil {
-			pathParts = pathParts[1:]
+		found := false
+		for i, p := range pathParts {
+			if _, err := parseVersion(p); err == nil {
+				found = true
+				if i == 0 {
+					pathParts = pathParts[1:]
+					url.Path = "/"
+				} else {
+					url.Path = pathParts[0] + "/"
+					pathParts = pathParts[2:]
+				}
+				break
+			}
 		}
-		url.Path = "/"
+		if !found {
+			url.Path = path.Join(pathParts...) + "/"
+			pathParts = []string{}
+		}
 	}
 
-	baseURL := url.String()
+	getVersionURL := url.String()
 
 	// If this is an object-store serviceType, or an object-store container endpoint,
 	// there is no list version API call to make. Return a apiURLVersion which will
 	// satisfy a requested api version of "", "v1" or "v1.0"
 	if c.serviceURLs["object-store"] != "" && strings.Contains(serviceCatalogURL, c.serviceURLs["object-store"]) {
-		objectStoreLink := apiVersionLink{Href: baseURL, Rel: "self"}
+		url.Path = "/"
+		objectStoreLink := apiVersionLink{Href: url.String(), Rel: "self"}
 		objectStoreApiVersionInfo := []apiVersionInfo{
 			{
 				Version: apiVersion{major: 1, minor: 0},
@@ -181,18 +221,10 @@ func (c *authenticatingClient) getAPIVersions(serviceCatalogURL string) (*apiURL
 				Status:  "stable",
 			},
 		}
-		return &apiURLVersion{*url, strings.Join(origPathParts, "/"), objectStoreApiVersionInfo}, nil
+		apiURLVersionInfo := &apiURLVersion{*url, strings.Join(origPathParts, "/"), objectStoreApiVersionInfo}
+		c.apiURLVersions[serviceCatalogURL] = apiURLVersionInfo
+		return apiURLVersionInfo, nil
 	}
-
-	// Make sure we haven't already received the version info.
-	c.apiVersionMu.Lock()
-	defer c.apiVersionMu.Unlock()
-	if apiInfo, ok := c.apiURLVersions[baseURL]; ok {
-		return apiInfo, nil
-	}
-
-	logger := logging.FromCompat(c.logger)
-	logger.Debugf("performing API version discovery for %q", baseURL)
 
 	var raw struct {
 		Versions json.RawMessage `json:"versions"`
@@ -208,27 +240,23 @@ func (c *authenticatingClient) getAPIVersions(serviceCatalogURL string) (*apiURL
 		rootURL:          *url,
 		serviceURLSuffix: strings.Join(pathParts, "/"),
 	}
-	if err := c.sendRequest("GET", baseURL, c.Token(), requestData); err != nil {
-		if gooseerrors.IsNotFound(err) {
-			// Some OpenStack clouds do not support the
-			// version endpoint, and will return a status
-			// code of 404. We check for 404 and return an
-			// empty set of versions.
-			logger.Warningf("API version discovery failed: %v", err)
-			c.apiURLVersions[baseURL] = apiURLVersionInfo
-			return apiURLVersionInfo, nil
-		}
-		return nil, err
+	if err := c.sendRequest("GET", getVersionURL, c.Token(), requestData); err != nil {
+		logger.Debugf("API version discovery failed: %v", err)
+		c.apiURLVersions[serviceCatalogURL] = apiURLVersionInfo
+		return apiURLVersionInfo, nil
 	}
 
 	versions, err := unmarshallVersion(raw.Versions)
 	if err != nil {
-		return nil, err
+		logger.Debugf("API version discovery unmarshallVersion failed: %v", err)
+		c.apiURLVersions[serviceCatalogURL] = apiURLVersionInfo
+		return apiURLVersionInfo, nil
 	}
 	apiURLVersionInfo.versions = versions
 	logger.Debugf("discovered API versions: %+v", versions)
 
 	// Cache the result.
-	c.apiURLVersions[baseURL] = apiURLVersionInfo
+	c.apiURLVersions[serviceCatalogURL] = apiURLVersionInfo
+
 	return apiURLVersionInfo, nil
 }

--- a/client/apiversion_test.go
+++ b/client/apiversion_test.go
@@ -142,6 +142,14 @@ func (s *localLiveSuite) makeServiceURLTests() []makeServiceURLTest {
 			success:     true,
 			URL:         "http://localhost:%s/compute/v2.1/servers/",
 		},
+		{
+			// See https://bugs.launchpad.net/juju/+bug/1756135
+			serviceType: "compute4",
+			version:     "v2",
+			parts:       []string{"servers/"},
+			success:     true,
+			URL:         "http://localhost:%s/computev1/v2.1/servers/",
+		},
 	}
 }
 

--- a/client/apiversion_test.go
+++ b/client/apiversion_test.go
@@ -118,6 +118,30 @@ func (s *localLiveSuite) makeServiceURLTests() []makeServiceURLTest {
 			success:     false,
 			err:         "no endpoints known for service type: no-such-service",
 		},
+		{
+			// See https://bugs.launchpad.net/juju/+bug/1756135
+			serviceType: "compute2",
+			version:     "v2.1",
+			parts:       []string{"servers/"},
+			success:     true,
+			URL:         "http://localhost:%s/v2.1/010ab46135ba414882641f663ec917b6/servers/",
+		},
+		{
+			// See https://bugs.launchpad.net/juju/+bug/1756135
+			serviceType: "compute3",
+			version:     "v4.2",
+			parts:       []string{"servers/"},
+			success:     true,
+			URL:         "http://localhost:%s/compute/v4.2/servers/",
+		},
+		{
+			// See https://bugs.launchpad.net/juju/+bug/1756135
+			serviceType: "compute3",
+			version:     "v2",
+			parts:       []string{"servers/"},
+			success:     true,
+			URL:         "http://localhost:%s/compute/v2.1/servers/",
+		},
 	}
 }
 
@@ -189,13 +213,15 @@ func (s *localLiveSuite) TestMakeServiceURLValues(c *gc.C) {
 const authInformationBody = `{"versions": [` +
 	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v3.4", "links": [{"href": "%s/v3/", "rel": "self"}]},` +
 	`{"status": "stable", "updated": "2014-04-17T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v2.0+json"}], "id": "v2.0", "links": [{"href": "%s/v2.0/", "rel": "self"}, {"href": "http://docs.openstack.org/", "type": "text/html", "rel": "describedby"}]},` +
-	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v2.1", "links": [{"href": "%s/v2.1/", "rel": "self"}]}` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v2.1", "links": [{"href": "%s/v2.1/", "rel": "self"}]},` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v4.2", "links": [{"href": "%s/compute/v4.2/", "rel": "self"}]}` +
 	`]}`
 
 const authValuesInformationBody = `{"versions": {"values": [` +
 	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v3.4", "links": [{"href": "%s/v3/", "rel": "self"}]},` +
 	`{"status": "stable", "updated": "2014-04-17T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v2.0+json"}], "id": "v2.0", "links": [{"href": "%s/v2.0/", "rel": "self"}, {"href": "http://docs.openstack.org/", "type": "text/html", "rel": "describedby"}]},` +
-	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v2.1", "links": [{"href": "%s/v2.1/", "rel": "self"}]}` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v2.1", "links": [{"href": "%s/v2.1/", "rel": "self"}]},` +
+	`{"status": "stable", "updated": "2015-03-30T00:00:00Z", "media-types": [{"base": "application/json", "type": "application/vnd.openstack.identity-v3+json"}], "id": "v4.2", "links": [{"href": "%s/compute/v4.2/", "rel": "self"}]}` +
 	`]}}`
 
 func (vh *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -206,7 +232,7 @@ func (vh *versionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(body))
 		return
 	}
-	body := []byte(fmt.Sprintf(vh.authBody, "http://localhost:"+vh.port, "http://localhost:"+vh.port, "http://localhost:"+vh.port))
+	body := []byte(fmt.Sprintf(vh.authBody, "http://localhost:"+vh.port, "http://localhost:"+vh.port, "http://localhost:"+vh.port, "http://localhost:"+vh.port))
 	// workaround for https://code.google.com/p/go/issues/detail?id=4454
 	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
 	w.WriteHeader(http.StatusMultipleChoices)

--- a/client/client.go
+++ b/client/client.go
@@ -250,9 +250,9 @@ func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, pa
 
 	defer func() {
 		if returnURL != "" {
-			logger.Tracef("MakeServiceURL: %s",returnURL)
+			logger.Tracef("MakeServiceURL: %s", returnURL)
 		}
-	} ()
+	}()
 
 	if apiVersion == "" || !c.isAPIVersionDiscoveryEnabled() {
 		return makeURL(serviceURL, parts), nil
@@ -273,7 +273,7 @@ func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, pa
 		logger.Warningf("falling back to catalogue service URL")
 		return makeURL(serviceURL, parts), nil
 	}
-	serviceURL, err = getAPIVersionURL(apiURLVersionInfo, requestedVersion)
+	serviceURL, err = c.getAPIVersionURL(apiURLVersionInfo, requestedVersion)
 	if err != nil {
 		return "", err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -238,14 +238,22 @@ func (c *authenticatingClient) sendAuthRequest(
 // object-store and container service types have no versions. For these services, the
 // caller may pass "" for apiVersion, to use the service catalogue URL without any
 // version discovery.
-func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, parts []string) (string, error) {
+func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, parts []string) (returnURL string, _ error) {
 	if !c.IsAuthenticated() {
 		return "", errors.New("cannot get endpoint URL without being authenticated")
 	}
+	logger := logging.FromCompat(c.logger)
 	serviceURL, ok := c.serviceURLs[serviceType]
 	if !ok {
 		return "", errors.New("no endpoints known for service type: " + serviceType)
 	}
+
+	defer func() {
+		if returnURL != "" {
+			logger.Tracef("MakeServiceURL: %s",returnURL)
+		}
+	} ()
+
 	if apiVersion == "" || !c.isAPIVersionDiscoveryEnabled() {
 		return makeURL(serviceURL, parts), nil
 	}
@@ -262,7 +270,6 @@ func (c *authenticatingClient) MakeServiceURL(serviceType, apiVersion string, pa
 		// so just use the service URL as if discovery were
 		// disabled. This isn't guaranteed to result in a valid
 		// endpoint, but it's the best we can do.
-		logger := logging.FromCompat(c.logger)
 		logger.Warningf("falling back to catalogue service URL")
 		return makeURL(serviceURL, parts), nil
 	}

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -225,6 +225,10 @@ func (auth *fakeAuthenticator) Auth(creds *identity.Credentials) (*identity.Auth
 	URLs := make(map[string]identity.ServiceURLs)
 	endpoints := make(map[string]string)
 	endpoints["compute"] = fmt.Sprintf("http://localhost:%s", auth.port)
+	// Special case for LP: 1756135
+	endpoints["compute2"] = fmt.Sprintf("http://localhost:%s/v2/010ab46135ba414882641f663ec917b6", auth.port)
+	// Special case for LP: 1756135
+	endpoints["compute3"] = fmt.Sprintf("http://localhost:%s/compute", auth.port)
 	endpoints["object-store"] = fmt.Sprintf("http://localhost:%s/swift/v1", auth.port)
 	endpoints["juju-container-test"] = fmt.Sprintf("http://localhost:%s/swift/v1", auth.port)
 	URLs[creds.Region] = endpoints

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -225,10 +225,12 @@ func (auth *fakeAuthenticator) Auth(creds *identity.Credentials) (*identity.Auth
 	URLs := make(map[string]identity.ServiceURLs)
 	endpoints := make(map[string]string)
 	endpoints["compute"] = fmt.Sprintf("http://localhost:%s", auth.port)
-	// Special case for LP: 1756135
+	// Special case for https://bugs.launchpad.net/juju/+bug/1756135
 	endpoints["compute2"] = fmt.Sprintf("http://localhost:%s/v2/010ab46135ba414882641f663ec917b6", auth.port)
-	// Special case for LP: 1756135
+	// Special case for https://bugs.launchpad.net/juju/+bug/1756135
 	endpoints["compute3"] = fmt.Sprintf("http://localhost:%s/compute", auth.port)
+	// Special case for https://bugs.launchpad.net/juju/+bug/1756135
+	endpoints["compute4"] = fmt.Sprintf("http://localhost:%s/computev1/v2", auth.port)
 	endpoints["object-store"] = fmt.Sprintf("http://localhost:%s/swift/v1", auth.port)
 	endpoints["juju-container-test"] = fmt.Sprintf("http://localhost:%s/swift/v1", auth.port)
 	URLs[creds.Region] = endpoints

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -26,6 +26,7 @@ type CompatLogger interface {
 type Logger interface {
 	Debugf(format string, v ...interface{})
 	Warningf(format string, v ...interface{})
+	Tracef(format string, v ...interface{})
 }
 
 // LoggoLogger is a logger that may be provided when constructing
@@ -55,6 +56,11 @@ func (a CompatLoggerAdapter) Debugf(format string, v ...interface{}) {
 // Warningf is part of the Logger interface.
 func (a CompatLoggerAdapter) Warningf(format string, v ...interface{}) {
 	a.Printf("WARNING: "+format, v...)
+}
+
+// Tracef is part of the Logger interface.
+func (a CompatLoggerAdapter) Tracef(format string, v ...interface{}) {
+	a.Printf("TRACE: "+format, v...)
 }
 
 // FromCompat takes a CompatLogger, and returns a Logger. This function


### PR DESCRIPTION
during api version discovery.  Provide coverage to additional OpenStack deployments.
Add Trace to client logging.

Tested against the on-site config, openstack and rackspace, and additional unit tests.
