### PR TITLE
add client.NewClientTLSConfig

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/url"
@@ -169,12 +170,16 @@ func newClient(creds *identity.Credentials, auth_method identity.AuthMode, httpC
 	return &client
 }
 
-func NewClient(creds *identity.Credentials, auth_method identity.AuthMode, logger logging.CompatLogger) AuthenticatingClient {
-	return newClient(creds, auth_method, sharedHttpClient, logger)
+func NewClient(creds *identity.Credentials, authMethod identity.AuthMode, logger logging.CompatLogger) AuthenticatingClient {
+	return newClient(creds, authMethod, sharedHttpClient, logger)
 }
 
-func NewNonValidatingClient(creds *identity.Credentials, auth_method identity.AuthMode, logger logging.CompatLogger) AuthenticatingClient {
-	return newClient(creds, auth_method, goosehttp.NewNonSSLValidating(), logger)
+func NewNonValidatingClient(creds *identity.Credentials, authMethod identity.AuthMode, logger logging.CompatLogger) AuthenticatingClient {
+	return newClient(creds, authMethod, goosehttp.NewNonSSLValidating(), logger)
+}
+
+func NewClientTLSConfig(creds *identity.Credentials, authMethod identity.AuthMode, logger logging.CompatLogger, config *tls.Config) AuthenticatingClient {
+	return newClient(creds, authMethod, goosehttp.NewWithTLSConfig(config), logger)
 }
 
 func (c *client) sendRequest(method, url, token string, requestData *goosehttp.RequestData) (err error) {

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -1,6 +1,8 @@
 package client_test
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -498,4 +500,24 @@ func (s *localHTTPSSuite) TestAuthDiscover(c *gc.C) {
 	options, err := cl.IdentityAuthOptions()
 	c.Assert(err, gc.IsNil)
 	c.Assert(options, gc.DeepEquals, identity.AuthOptions{identity.AuthOption{Mode: 3, Endpoint: s.cred.URL + "/v3/"}, identity.AuthOption{Mode: 1, Endpoint: s.cred.URL + "/v2.0/"}})
+}
+
+func (s *localHTTPSSuite) TestTLSConfigClientBadConfig(c *gc.C){
+	cl := client.NewClientTLSConfig(s.cred, identity.AuthUserPass, nil, &tls.Config{})
+	err := cl.Authenticate()
+	c.Assert(err, gc.ErrorMatches, "(.|\n)*x509: certificate signed by unknown authority")
+}
+
+func (s *localHTTPSSuite) TestTLSConfigClient(c *gc.C){
+	cl := client.NewClientTLSConfig(s.cred, identity.AuthUserPass, nil, s.tlsConfig())
+	err := cl.Authenticate()
+	c.Assert(err, gc.IsNil)
+}
+
+func (s * localHTTPSSuite) tlsConfig() *tls.Config{
+	pool := x509.NewCertPool()
+	pool.AddCert(s.HTTPSuite.Server.Certificate())
+	return &tls.Config{
+		RootCAs:pool,
+	}
 }

--- a/http/client.go
+++ b/http/client.go
@@ -113,6 +113,14 @@ func NewNonSSLValidating() *Client {
 	return &Client{*httpClient, MaxSendAttempts}
 }
 
+func NewWithTLSConfig(tlsConfig *tls.Config) *Client {
+	defaultClient := *http.DefaultClient
+	defaultClient.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	return &Client{defaultClient, MaxSendAttempts}
+}
+
 func gooseAgent() string {
 	return fmt.Sprintf("goose (%s)", goose.Version)
 }
@@ -311,6 +319,7 @@ func (c *Client) sendRateLimitedRequest(
 				io.Reader
 			}{notifier, reqReader}
 		}
+
 		req, err := http.NewRequest(method, URL, body)
 		if err != nil {
 			return nil, errors.Newf(err, "failed creating the request %s", URL)


### PR DESCRIPTION
add client.NewClientTLSConfig which accepts a *tls.Config for http.  Needed for juju bug:
https://bugs.launchpad.net/juju/+bug/1777897