### PR TITLE
client: ensure requests are restarted in a race-free way.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"sort"
 	"strings"
@@ -162,9 +161,9 @@ func newClient(creds *identity.Credentials, auth_method identity.AuthMode, httpC
 		client_creds.URL = client_creds.URL + apiTokens
 	}
 	client := authenticatingClient{
-		creds:                &client_creds,
-		requiredServiceTypes: defaultRequiredServiceTypes,
-		client:               client{logger: logger, httpClient: httpClient},
+		creds:                      &client_creds,
+		requiredServiceTypes:       defaultRequiredServiceTypes,
+		client:                     client{logger: logger, httpClient: httpClient},
 		apiVersionDiscoveryEnabled: true,
 	}
 	client.auth = &client
@@ -217,21 +216,18 @@ func (c *authenticatingClient) SendRequest(
 	method, svcType, apiVersion, apiCall string,
 	requestData *goosehttp.RequestData,
 ) (err error) {
-	var rs io.ReadSeeker
-	rs, err = gooseio.Seekable(requestData.ReqReader, int64(requestData.ReqLength))
-	if err != nil {
-		return
+	if requestData.ReqReader != nil && requestData.GetReqReader == nil {
+		requestData.ReqReader, requestData.GetReqReader = gooseio.MakeGetReqReader(requestData.ReqReader, int64(requestData.ReqLength))
 	}
-	requestData.ReqReader = rs
 	err = c.sendAuthRequest(method, svcType, apiVersion, apiCall, requestData)
 	if gooseerrors.IsUnauthorised(err) {
-		if rs != nil {
-			_, err = rs.Seek(0, 0)
+		c.setToken("")
+		if requestData.GetReqReader != nil {
+			requestData.ReqReader, err = requestData.GetReqReader()
 			if err != nil {
 				return
 			}
 		}
-		c.setToken("")
 		err = c.sendAuthRequest(method, svcType, apiVersion, apiCall, requestData)
 	}
 	return

--- a/internal/gooseio/package_test.go
+++ b/internal/gooseio/package_test.go
@@ -1,0 +1,11 @@
+package gooseio_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/internal/gooseio/seekable_test.go
+++ b/internal/gooseio/seekable_test.go
@@ -1,0 +1,71 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the LGPLv3, see COPYING and COPYING.LESSER file for details.
+
+package gooseio_test
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"sync"
+
+	gc "gopkg.in/check.v1"
+
+	"gopkg.in/goose.v2/internal/gooseio"
+)
+
+type getReqReaderSuite struct{}
+
+var _ = gc.Suite(&getReqReaderSuite{})
+
+func (s *getReqReaderSuite) TestConcurrentBuffered(c *gc.C) {
+	body := "test body"
+	var r0 struct{ io.Reader }
+	r0.Reader = strings.NewReader(body)
+	r, getBody := gooseio.MakeGetReqReader(r0, int64(len(body)))
+	s.testConcurrent(c, r, getBody, body)
+}
+
+func (s *getReqReaderSuite) TestConcurrentSeekable(c *gc.C) {
+	body := "test body"
+	r, getBody := gooseio.MakeGetReqReader(strings.NewReader(body), int64(len(body)))
+	s.testConcurrent(c, r, getBody, body)
+}
+
+func (s *getReqReaderSuite) testConcurrent(c *gc.C, r io.ReadCloser, getBody func() (io.ReadCloser, error), body string) {
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r, err := getBody()
+			if err != nil {
+				c.Error(err)
+				return
+			}
+			defer r.Close()
+			received, err := ioutil.ReadAll(r)
+			c.Check(err, gc.Equals, nil)
+			c.Check(string(received), gc.Equals, body)
+		}()
+	}
+	r.Close()
+	wg.Wait()
+}
+
+func (s *getReqReaderSuite) TestBufferedEarlyClose(c *gc.C) {
+	body := "test body"
+	var r0 struct{ io.Reader }
+	r0.Reader = strings.NewReader(body)
+	r, getBody := gooseio.MakeGetReqReader(r0, int64(len(body)))
+
+	var buf [5]byte
+	_, err := io.ReadFull(r, buf[:])
+	c.Assert(err, gc.Equals, nil)
+	r.Close()
+	r, err = getBody()
+	c.Assert(err, gc.Equals, nil)
+	buf2, err := ioutil.ReadAll(r)
+	c.Assert(err, gc.Equals, nil)
+	c.Assert(string(buf2), gc.Equals, body)
+}


### PR DESCRIPTION
HTTP clients can return whilst they are still reading a request
body. Ensure that any request with a body is not restarted until the
previous request has closed it.