### PR TITLE
Added block_device_mapping_v2 to RunServer API

### DIFF
--- a/nova/json.go
+++ b/nova/json.go
@@ -112,6 +112,10 @@ func (entity Entity) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Image response id can be empty when using block device mapping.
+	if entity.Id == "" {
+		return data, nil
+	}
 	id := convertId(entity.Id)
 	return appendJSON(data, idTag, id)
 }

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -325,15 +325,34 @@ type ServerNetworks struct {
 
 // RunServerOpts defines required and optional arguments for RunServer().
 type RunServerOpts struct {
-	Name               string              `json:"name"`                        // Required
-	FlavorId           string              `json:"flavorRef"`                   // Required
-	ImageId            string              `json:"imageRef"`                    // Required
-	UserData           []byte              `json:"user_data,omitempty"`         // Optional
-	SecurityGroupNames []SecurityGroupName `json:"security_groups,omitempty"`   // Optional
-	Networks           []ServerNetworks    `json:"networks"`                    // Optional
-	AvailabilityZone   string              `json:"availability_zone,omitempty"` // Optional
-	Metadata           map[string]string   `json:"metadata,omitempty"`          // Optional
-	ConfigDrive        bool                `json:"config_drive,omitempty"`      // Optional
+	Name                string               `json:"name"`                              // Required
+	FlavorId            string               `json:"flavorRef"`                         // Required
+	ImageId             string               `json:"imageRef,omitempty"`                // Optional
+	UserData            []byte               `json:"user_data,omitempty"`               // Optional
+	SecurityGroupNames  []SecurityGroupName  `json:"security_groups,omitempty"`         // Optional
+	Networks            []ServerNetworks     `json:"networks"`                          // Optional
+	AvailabilityZone    string               `json:"availability_zone,omitempty"`       // Optional
+	Metadata            map[string]string    `json:"metadata,omitempty"`                // Optional
+	ConfigDrive         bool                 `json:"config_drive,omitempty"`            // Optional
+	BlockDeviceMappings []BlockDeviceMapping `json:"block_device_mapping_v2,omitempty"` // Optional
+}
+
+// BlockDeviceMapping defines block devices to be attached to the Server created by RunServer().
+// See: https://developer.openstack.org/api-ref/compute/?expanded=create-server-detail
+type BlockDeviceMapping struct {
+	BootIndex           int    `json:"boot_index"`
+	UUID                string `json:"uuid,omitempty"`
+	SourceType          string `json:"source_type,omitempty"`
+	DestinationType     string `json:"destination_type,omitempty"`
+	VolumeSize          int    `json:"volume_size,omitempty"`
+	VolumeType          string `json:"volume_type,omitempty"`
+	DeleteOnTermination bool   `json:"delete_on_termination,omitempty"`
+	DeviceName          string `json:"device_name,omitempty"`
+	DeviceType          string `json:"device_type,omitempty"`
+	DiskBus             string `json:"disk_bus,omitempty"`
+	GuestFormat         string `json:"guest_format,omitempty"`
+	NoDevice            bool   `json:"no_device,omitempty"`
+	Tag                 string `json:"tag,omitempty"`
 }
 
 // RunServer creates a new server, based on the given RunServerOpts.

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -602,13 +602,14 @@ func noGroupError(groupName, tenantId string) error {
 func (n *Nova) handleRunServer(body []byte, w http.ResponseWriter, r *http.Request) error {
 	var req struct {
 		Server struct {
-			FlavorRef        string
-			ImageRef         string
-			Name             string
-			Metadata         map[string]string
-			SecurityGroups   []map[string]string `json:"security_groups"`
-			Networks         []map[string]string
-			AvailabilityZone string `json:"availability_zone"`
+			FlavorRef          string
+			ImageRef           string
+			Name               string
+			Metadata           map[string]string
+			SecurityGroups     []map[string]string `json:"security_groups"`
+			Networks           []map[string]string
+			AvailabilityZone   string                    `json:"availability_zone"`
+			BlockDeviceMapping []nova.BlockDeviceMapping `json:"block_device_mapping_v2,omitempty"`
 		}
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -617,7 +618,7 @@ func (n *Nova) handleRunServer(body []byte, w http.ResponseWriter, r *http.Reque
 	if req.Server.Name == "" {
 		return errBadRequestSrvName
 	}
-	if req.Server.ImageRef == "" {
+	if req.Server.ImageRef == "" && req.Server.BlockDeviceMapping == nil {
 		return errBadRequestSrvImage
 	}
 	if req.Server.FlavorRef == "" {


### PR DESCRIPTION
Added BlockDeviceMappings field to RunServerOpts to allow for fine grained control over block devices when creating a server on OpenStack.
Also changed ImageRef to be optional, as this should only be specified when using legacy OpenStack create-server behaviour.

See https://developer.openstack.org/api-ref/compute/?expanded=create-server-detail on the block_device_mapping_v2 schema.