### PR TITLE
Port V2 API calls

### DIFF
--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -344,6 +344,15 @@ func (s *LiveTests) TestPortsV2(c *gc.C) {
 	if !found {
 		c.Errorf("expected to find added port %s", newPort)
 	}
+
+	port1 := ports[0]
+
+	filter := neutron.NewFilter()
+	filter.Set(neutron.FilterProjectId, port1.TenantId)
+	ports, err = s.neutron.ListPortsV2(filter)
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.HasLen, 1)
+	c.Assert(ports[0].Id, gc.Equals, port1.Id)
 }
 
 func (s *LiveTests) TestPortByIdV2(c *gc.C) {

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -344,9 +344,6 @@ func (s *LiveTests) TestPortsV2(c *gc.C) {
 	if !found {
 		c.Errorf("expected to find added port %s", newPort)
 	}
-
-	_, err = s.neutron.PortByIdV2(newPort.Id)
-	c.Assert(err, gc.Not(gc.IsNil))
 }
 
 func (s *LiveTests) TestPortByIdV2(c *gc.C) {
@@ -369,5 +366,22 @@ func (s *LiveTests) TestPortByIdV2(c *gc.C) {
 
 	// Try to find a Port that doesn't exist
 	_, err = s.neutron.PortByIdV2("xunknown-port-idxx-8205-9b711a3531b7")
+	c.Assert(err, gc.Not(gc.IsNil))
+}
+
+func (s *LiveTests) TestPortsDeleteV2(c *gc.C) {
+	port := neutron.PortV2{
+		Name:        "PortTest",
+		Description: "Testing create port",
+		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+	}
+	newPort, err := s.neutron.CreatePortV2(port)
+	c.Assert(err, gc.IsNil)
+	c.Assert(newPort, gc.Not(gc.IsNil))
+
+	err = s.neutron.DeletePortV2(newPort.Id)
+	c.Assert(err, gc.IsNil)
+
+	_, err = s.neutron.PortByIdV2(newPort.Id)
 	c.Assert(err, gc.Not(gc.IsNil))
 }

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -1,8 +1,9 @@
 package neutron_test
 
 import (
-	gc "gopkg.in/check.v1"
 	"net"
+
+	gc "gopkg.in/check.v1"
 
 	"gopkg.in/goose.v2/client"
 	"gopkg.in/goose.v2/identity"
@@ -306,4 +307,67 @@ func (s *LiveTests) TestSecurityGroupsRulesV2(c *gc.C) {
 	}
 	err = s.neutron.DeleteSecurityGroupRuleV2(newSecGrpRule.Id)
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *LiveTests) deletePort(id string, c *gc.C) {
+	err := s.neutron.DeletePortV2(id)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *LiveTests) TestPortsV2(c *gc.C) {
+	port := neutron.PortV2{
+		Name:        "PortTest",
+		Description: "Testing create port",
+		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+	}
+	newPort, err := s.neutron.CreatePortV2(port)
+	c.Assert(err, gc.IsNil)
+	defer s.deletePort(newPort.Id, c)
+	c.Assert(newPort, gc.Not(gc.IsNil))
+
+	ports, err := s.neutron.ListPortsV2()
+	c.Assert(err, gc.IsNil)
+	c.Assert(ports, gc.Not(gc.HasLen), 0)
+
+	var found bool
+	for _, port := range ports {
+		c.Check(port.Id, gc.Not(gc.Equals), "")
+		c.Check(port.Name, gc.Not(gc.Equals), "")
+		c.Check(port.Description, gc.Not(gc.Equals), "")
+		c.Check(port.TenantId, gc.Not(gc.Equals), "")
+		c.Check(port.NetworkId, gc.Not(gc.Equals), "")
+		// Is this the Port we just created?
+		if port.Id == newPort.Id {
+			found = true
+		}
+	}
+	if !found {
+		c.Errorf("expected to find added port %s", newPort)
+	}
+
+	_, err = s.neutron.PortByIdV2(newPort.Id)
+	c.Assert(err, gc.Not(gc.IsNil))
+}
+
+func (s *LiveTests) TestPortByIdV2(c *gc.C) {
+	// Create and find a Port
+	port := neutron.PortV2{
+		Name:        "PortTest",
+		Description: "Testing create port",
+		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+	}
+	newPort, err := s.neutron.CreatePortV2(port)
+	c.Assert(err, gc.IsNil)
+	defer s.deletePort(newPort.Id, c)
+	c.Assert(newPort, gc.Not(gc.IsNil))
+
+	foundPort, err := s.neutron.PortByIdV2(newPort.Id)
+	c.Assert(err, gc.IsNil)
+	if newPort.Id != foundPort.Id {
+		c.Errorf("expected to find added port %s, when requested by Id", newPort.Id)
+	}
+
+	// Try to find a Port that doesn't exist
+	_, err = s.neutron.PortByIdV2("xunknown-port-idxx-8205-9b711a3531b7")
+	c.Assert(err, gc.Not(gc.IsNil))
 }

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -270,7 +270,7 @@ func (c *Client) PortByIdV2(portId string) (PortV2, error) {
 	var resp struct {
 		Port PortV2 `json:"port"`
 	}
-	url := fmt.Sprintf("%s?port_id=%s", ApiSecurityGroupsV2, url.QueryEscape(portId))
+	url := fmt.Sprintf("%s/%s", ApiPortsV2, url.QueryEscape(portId))
 	requestData := goosehttp.RequestData{RespValue: &resp}
 	err := c.client.SendRequest(client.GET, "network", "v2.0", url, &requestData)
 	if err != nil {

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -233,19 +233,21 @@ func (c *Client) DeleteFloatingIPV2(ipId string) error {
 	return err
 }
 
-// PortV2 describes a defined network for creating a port.
+// PortV2 describes a defined network for administrating a port.
 type PortV2 struct {
-	Description    string           `json:"description,omitempty"`
-	FixedIPs       []PortFixedIPsV2 `json:"fixed_ips,omitempty"`
-	Id             string           `json:"id,omitempty"`
-	Name           string           `json:"name,omitempty"`
-	NetworkId      string           `json:"network_id"`
-	SecurityGroups []string         `json:"security_groups,omitempty"`
-	Status         string           `json:"status,omitempty"`
-	TenantId       string           `json:"tenant_id,omitempty"`
+	Description         string           `json:"description,omitempty"`
+	DeviceId            string           `json:"device_id,omitempty"`
+	FixedIPs            []PortFixedIPsV2 `json:"fixed_ips,omitempty"`
+	Id                  string           `json:"id,omitempty"`
+	Name                string           `json:"name,omitempty"`
+	NetworkId           string           `json:"network_id"`
+	PortSecurityEnabled bool             `json:"port_security_enabled,omitempty"`
+	SecurityGroups      []string         `json:"security_groups,omitempty"`
+	Status              string           `json:"status,omitempty"`
+	TenantId            string           `json:"tenant_id,omitempty"`
 }
 
-// PortFixedIPsV2 represents a FIxedIp with ip addresses and an associated
+// PortFixedIPsV2 represents a FixedIp with ip addresses and an associated
 // subnet id.
 type PortFixedIPsV2 struct {
 	IPAddress string `json:"ip_address"`
@@ -253,11 +255,15 @@ type PortFixedIPsV2 struct {
 }
 
 // ListPortsV2 lists NetworkIds, names, and other details for all ports.
-func (c *Client) ListPortsV2() ([]PortV2, error) {
+func (c *Client) ListPortsV2(filter ...*Filter) ([]PortV2, error) {
 	var resp struct {
 		Ports []PortV2 `json:"ports"`
 	}
-	requestData := goosehttp.RequestData{RespValue: &resp}
+	var params *url.Values
+	if len(filter) > 0 {
+		params = &filter[0].v
+	}
+	requestData := goosehttp.RequestData{RespValue: &resp, Params: params}
 	err := c.client.SendRequest(client.GET, "network", "v2.0", ApiPortsV2, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to list ports")

--- a/testservices/errors.go
+++ b/testservices/errors.go
@@ -104,6 +104,14 @@ func NewServerAlreadyExistsError(id string) *ServerError {
 	return serverErrorf(409, "A server with id %q already exists", id)
 }
 
+func NewPortAlreadyExistsError(id string) *ServerError {
+	return serverErrorf(409, "A port with id %s already exists", id)
+}
+
+func NewPortByIDNotFoundError(portId string) *ServerError {
+	return serverErrorf(404, "No such port %s", portId)
+}
+
 func NewSecurityGroupAlreadyExistsError(id string) *ServerError {
 	return serverErrorf(409, "A security group with id %s already exists", id)
 }

--- a/testservices/neutronservice/service.go
+++ b/testservices/neutronservice/service.go
@@ -28,6 +28,7 @@ type Neutron struct {
 	subnets      map[string]neutron.SubnetV2
 	nextGroupId  int
 	nextRuleId   int
+	nextPortId   int
 	nextIPId     int
 }
 
@@ -141,6 +142,35 @@ func (n *Neutron) updateSecurityGroup(group neutron.SecurityGroupV2) error {
 		return err
 	}
 	return n.neutronModel.UpdateSecurityGroup(group)
+}
+
+// addPort creates a new port.
+func (n *Neutron) addPort(port neutron.PortV2) error {
+	if err := n.ProcessFunctionHook(n, port); err != nil {
+		return err
+	}
+	return n.neutronModel.AddPort(port)
+}
+
+// port retrieves an existing port by ID.
+func (n *Neutron) port(portId string) (*neutron.PortV2, error) {
+	if err := n.ProcessFunctionHook(n, portId); err != nil {
+		return nil, err
+	}
+	return n.neutronModel.Port(portId)
+}
+
+// allPorts returns a list of all existing ports.
+func (n *Neutron) allPorts() []neutron.PortV2 {
+	return n.neutronModel.AllPorts()
+}
+
+// removePort deletes an existing port.
+func (n *Neutron) removePort(portId string) error {
+	if err := n.ProcessFunctionHook(n, portId); err != nil {
+		return err
+	}
+	return n.neutronModel.RemovePort(portId)
 }
 
 // addSecurityGroup creates a new security group.

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -596,13 +596,7 @@ func (n *Neutron) handlePorts(w http.ResponseWriter, r *http.Request) error {
 			return errBadRequestIncorrect
 		}
 		var req struct {
-			Port struct {
-				Name        string
-				Description string
-				FixedIPs    []neutron.PortFixedIPsV2
-				NetworkId   string
-				Status      string
-			} `json:"port"`
+			Port neutron.PortV2 `json:"port"`
 		}
 		if err := json.Unmarshal(body, &req); err != nil {
 			return err

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -22,6 +22,7 @@ const (
 	authToken               = "X-Auth-Token"
 	apiFloatingIPsV2        = "/v2.0/" + neutron.ApiFloatingIPsV2
 	apiNetworksV2           = "/v2.0/" + neutron.ApiNetworksV2
+	apiPortsV2              = "/v2.0/" + neutron.ApiPortsV2
 	apiSubnetsV2            = "/v2.0/" + neutron.ApiSubnetsV2
 	apiSecurityGroupsV2     = "/v2.0/" + neutron.ApiSecurityGroupsV2
 	apiSecurityGroupRulesV2 = "/v2.0/" + neutron.ApiSecurityGroupRulesV2
@@ -118,6 +119,14 @@ The resource could not be found.
 		nil,
 		nil,
 	}
+	errNotFoundJSONP = &errorResponse{
+		http.StatusNotFound,
+		`{"itemNotFound": {"message": "Port $ID$ not found.", "code": 404}}`,
+		"application/json; charset=UTF-8",
+		"",
+		nil,
+		nil,
+	}
 	errMultipleChoices = &errorResponse{
 		http.StatusMultipleChoices,
 		`{"choices": [{"status": "CURRENT", "media-types": [{"base": ` +
@@ -148,6 +157,9 @@ The resource could not be found.
 	}
 	errNoGroupId = &errorResponse{
 		errorText: "no security group id given",
+	}
+	errNoPortId = &errorResponse{
+		errorText: "no port id given",
 	}
 	errRateLimitExceeded = &errorResponse{
 		http.StatusRequestEntityTooLarge,
@@ -539,6 +551,103 @@ func (n *Neutron) handleSecurityGroupRules(w http.ResponseWriter, r *http.Reques
 	return fmt.Errorf("unknown request method %q for %s", r.Method, r.URL.Path)
 }
 
+// processPortId returns the group if one is specified in the given request,
+// either by id or by ?name. If there was no group id specified in the path,
+// it returns errNoPortId
+func (n *Neutron) processPortId(w http.ResponseWriter, r *http.Request) (*neutron.PortV2, error) {
+	portId := path.Base(r.URL.Path)
+	apiFunc := path.Base(apiPortsV2)
+	if portId != apiFunc {
+		port, err := n.port(portId)
+		if err != nil {
+			return nil, errNotFoundJSONP
+		}
+		return port, nil
+	}
+	return nil, errNoPortId
+}
+
+// handlePorts handles the /v2.0/ports HTTP API.
+func (n *Neutron) handlePorts(w http.ResponseWriter, r *http.Request) error {
+	switch r.Method {
+	case "GET":
+		port, err := n.processPortId(w, r)
+		if err == errNoPortId {
+			resp := struct {
+				Ports []neutron.PortV2 `json:"ports"`
+			}{n.allPorts()}
+			return sendJSON(http.StatusOK, resp, w, r)
+		}
+		if err != nil {
+			return err
+		}
+		resp := struct {
+			Port neutron.PortV2 `json:"port"`
+		}{*port}
+
+		return sendJSON(http.StatusOK, resp, w, r)
+	case "POST":
+		_, err := n.processPortId(w, r)
+		if err != errNoPortId {
+			return errNotFound
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil || len(body) == 0 {
+			return errBadRequestIncorrect
+		}
+		var req struct {
+			Port struct {
+				Name        string
+				Description string
+				FixedIPs    []neutron.PortFixedIPsV2
+				NetworkId   string
+				Status      string
+			} `json:"port"`
+		}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return err
+		} else {
+			n.nextPortId++
+			nextId := strconv.Itoa(n.nextPortId)
+			err = n.addPort(neutron.PortV2{
+				Id:          nextId,
+				Name:        req.Port.Name,
+				Description: req.Port.Description,
+				FixedIPs:    req.Port.FixedIPs,
+				NetworkId:   req.Port.NetworkId,
+				Status:      req.Port.Status,
+				TenantId:    n.TenantId,
+			})
+			if err != nil {
+				return err
+			}
+			port, err := n.port(nextId)
+			if err != nil {
+				return err
+			}
+			var resp struct {
+				Port neutron.PortV2 `json:"port"`
+			}
+			resp.Port = *port
+			return sendJSON(http.StatusCreated, resp, w, r)
+		}
+
+	case "DELETE":
+		if port, err := n.processPortId(w, r); port != nil {
+			if err := n.removePort(port.Id); err != nil {
+				return err
+			}
+			writeResponse(w, http.StatusNoContent, nil)
+			return nil
+		} else if err == errNoPortId {
+			return errNotFound
+		} else {
+			return err
+		}
+	}
+	return fmt.Errorf("unknown request method %q for %s", r.Method, r.URL.Path)
+}
+
 // handleFloatingIPs handles the v2/floatingips HTTP API.
 func (n *Neutron) handleFloatingIPs(w http.ResponseWriter, r *http.Request) error {
 	switch r.Method {
@@ -703,6 +812,8 @@ func (n *Neutron) SetupHTTP(mux *http.ServeMux) {
 		"/$v/security-groups/":      n.handler((*Neutron).handleSecurityGroups),
 		"/$v/security-group-rules":  n.handler((*Neutron).handleSecurityGroupRules),
 		"/$v/security-group-rules/": n.handler((*Neutron).handleSecurityGroupRules),
+		"/$v/ports":                 n.handler((*Neutron).handlePorts),
+		"/$v/ports/":                n.handler((*Neutron).handlePorts),
 		"/$v/floatingips":           n.handler((*Neutron).handleFloatingIPs),
 		"/$v/floatingips/":          n.handler((*Neutron).handleFloatingIPs),
 		"/$v/networks":              n.handler((*Neutron).handleNetworks),

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -576,6 +576,7 @@ func (n *Neutron) handlePorts(w http.ResponseWriter, r *http.Request) error {
 			resp := struct {
 				Ports []neutron.PortV2 `json:"ports"`
 			}{n.allPorts()}
+
 			return sendJSON(http.StatusOK, resp, w, r)
 		}
 		if err != nil {

--- a/testservices/neutronservice/setup_test.go
+++ b/testservices/neutronservice/setup_test.go
@@ -13,9 +13,22 @@ func Test(t *testing.T) {
 }
 
 // checkGroupsInList checks that every group in groups is in groupList.
-func checkGroupsInList(c *gc.C, groups []neutron.SecurityGroupV2, groupList []neutron.SecurityGroupV2) {
+func checkGroupsInList(c *gc.C, groups, groupList []neutron.SecurityGroupV2) {
 	for _, g := range groups {
 		for _, gr := range groupList {
+			if g.Id == gr.Id {
+				c.Assert(g, gc.DeepEquals, gr)
+				return
+			}
+		}
+		c.Fail()
+	}
+}
+
+// checkPortsInList checks that every port in ports is in portList.
+func checkPortsInList(c *gc.C, ports, portList []neutron.PortV2) {
+	for _, g := range ports {
+		for _, gr := range portList {
 			if g.Id == gr.Id {
 				c.Assert(g, gc.DeepEquals, gr)
 				return


### PR DESCRIPTION
Adding the ability to create, get, list and delete a series of ports
for the neutron API.

The following code duplicates most of the existing work found with in
the neutron networking code, but adapts it for Ports. The API
documentation for the Ports API can be found[1].

This is required to provide spaces and multiple nic support to Juju. See
work in progress PR[2]

1. https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#ports
2. https://github.com/juju/juju/pull/11188