### PR TITLE
Omit empty on FixedIPsV2

### DIFF
--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -250,8 +250,8 @@ type PortV2 struct {
 // PortFixedIPsV2 represents a FixedIp with ip addresses and an associated
 // subnet id.
 type PortFixedIPsV2 struct {
-	IPAddress string `json:"ip_address"`
-	SubnetID  string `json:"subnet_id"`
+	IPAddress string `json:"ip_address,omitempty"`
+	SubnetID  string `json:"subnet_id,omitempty"`
 }
 
 // ListPortsV2 lists NetworkIds, names, and other details for all ports.


### PR DESCRIPTION
The following ensures that we don't have to supply a fixed ip address if
you're not likely to have one. Also, we invert that statement as well, as
you may have an IPAddress but not a subnet ID, so in both scenarios we
`omitempty`.

This should help with trying to create a port within Juju, but we don't
have an `ip_address`.