### PR TITLE
Neutron model test access

### DIFF
--- a/testservices/neutronservice/service.go
+++ b/testservices/neutronservice/service.go
@@ -136,6 +136,12 @@ func (n *Neutron) AddNeutronModel(neutronModel *neutronmodel.NeutronModel) {
 	n.neutronModel = neutronModel
 }
 
+// NeutronModel returns the current NeutronModel, which can then be used to
+// update internal state for neutron test doubles.
+func (n *Neutron) NeutronModel() *neutronmodel.NeutronModel {
+	return n.neutronModel
+}
+
 // updateSecurityGroup updates an existing security group.
 func (n *Neutron) updateSecurityGroup(group neutron.SecurityGroupV2) error {
 	if err := n.ProcessFunctionHook(n, group); err != nil {


### PR DESCRIPTION
In order to replicate how openstack performs certain duties at the
service layer, we need access to the underlying model to be able to
perform the same duties. This then allows us to exercise the code in
Juju.

In an ideal world this wouldn't need to be done, as Juju would have unit
tested at the right level instead of using blackbox testing at every
level.