### PR TITLE
Port tags

### DIFF
--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -319,6 +319,7 @@ func (s *LiveTests) TestPortsV2(c *gc.C) {
 		Name:        "PortTest",
 		Description: "Testing create port",
 		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		Tags:        []string{"tag0", "tag1"},
 	}
 	newPort, err := s.neutron.CreatePortV2(port)
 	c.Assert(err, gc.IsNil)
@@ -336,6 +337,7 @@ func (s *LiveTests) TestPortsV2(c *gc.C) {
 		c.Check(port.Description, gc.Not(gc.Equals), "")
 		c.Check(port.TenantId, gc.Not(gc.Equals), "")
 		c.Check(port.NetworkId, gc.Not(gc.Equals), "")
+		c.Check(port.Tags, gc.HasLen, 2)
 		// Is this the Port we just created?
 		if port.Id == newPort.Id {
 			found = true
@@ -352,7 +354,8 @@ func (s *LiveTests) TestPortsV2(c *gc.C) {
 	ports, err = s.neutron.ListPortsV2(filter)
 	c.Assert(err, gc.IsNil)
 	c.Assert(ports, gc.HasLen, 1)
-	c.Assert(ports[0].Id, gc.Equals, port1.Id)
+	c.Assert(ports[0].Name, gc.Equals, port.Name)
+	c.Assert(ports[0].Tags, gc.DeepEquals, port.Tags)
 }
 
 func (s *LiveTests) TestPortByIdV2(c *gc.C) {
@@ -361,6 +364,7 @@ func (s *LiveTests) TestPortByIdV2(c *gc.C) {
 		Name:        "PortTest",
 		Description: "Testing create port",
 		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		Tags:        []string{"tag0", "tag1"},
 	}
 	newPort, err := s.neutron.CreatePortV2(port)
 	c.Assert(err, gc.IsNil)
@@ -383,6 +387,7 @@ func (s *LiveTests) TestPortsDeleteV2(c *gc.C) {
 		Name:        "PortTest",
 		Description: "Testing create port",
 		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		Tags:        []string{"tag0", "tag1"},
 	}
 	newPort, err := s.neutron.CreatePortV2(port)
 	c.Assert(err, gc.IsNil)

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -244,6 +244,7 @@ type PortV2 struct {
 	PortSecurityEnabled bool             `json:"port_security_enabled,omitempty"`
 	SecurityGroups      []string         `json:"security_groups,omitempty"`
 	Status              string           `json:"status,omitempty"`
+	Tags                []string         `json:"tags,omitempty"`
 	TenantId            string           `json:"tenant_id,omitempty"`
 }
 

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -29,6 +29,22 @@ const (
 	FilterRouterExternal = "router:external" // The router:external
 	FilterNetwork        = "name"            // The network name.
 	FilterProjectId      = "project_id"      // The project id
+
+	// A list of tags to filter the list result by. Resources that match all tags in this
+	// list will be returned. Tags in query must be separated by comma.
+	FilterTags = "tags"
+
+	// 	A list of tags to filter the list result by. Resources that match any tag in this list
+	// will be returned. Tags in query must be separated by comma.
+	FilterTagsAny = "tags-any"
+
+	// A list of tags to filter the list result by. Resources that match all tags in this list
+	// will be excluded. Tags in query must be separated by comma.
+	FilterNotTags = "not-tags"
+
+	// A list of tags to filter the list result by. Resources that match any tag in this list
+	// will be excluded. Tags in query must be separated by comma.
+	FilterNotTagsAny = "not-tags-any"
 )
 
 // NetworkV2 contains details about a labeled network

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -611,6 +611,7 @@ func (n *Neutron) handlePorts(w http.ResponseWriter, r *http.Request) error {
 				FixedIPs:    req.Port.FixedIPs,
 				NetworkId:   req.Port.NetworkId,
 				Status:      req.Port.Status,
+				Tags:        req.Port.Tags,
 				TenantId:    n.TenantId,
 			})
 			if err != nil {

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -844,12 +844,14 @@ func (s *NeutronHTTPSuite) TestGetPorts(c *gc.C) {
 			Name:      "group 1",
 			TenantId:  s.service.TenantId,
 			NetworkId: "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+			Tags:      []string{"tag0", "tag1"},
 		},
 		{
 			Id:        "2",
 			Name:      "group 2",
 			TenantId:  s.service.TenantId,
 			NetworkId: "a87cc70a-3e15-4acf-8205-9b711a3531xx",
+			Tags:      []string{"tag3", "tag2"},
 		},
 	}
 
@@ -885,20 +887,23 @@ func (s *NeutronHTTPSuite) TestAddPort(c *gc.C) {
 		Description: "desc",
 		TenantId:    s.service.TenantId,
 		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531b7",
+		Tags:        []string{"tag0", "tag1"},
 	}
 	_, err := s.service.port(port.Id)
 	c.Assert(err, gc.NotNil)
 
 	var req struct {
 		Port struct {
-			Name        string `json:"name"`
-			Description string `json:"description"`
-			NetworkId   string `json:"network_id"`
+			Name        string   `json:"name"`
+			Description string   `json:"description"`
+			NetworkId   string   `json:"network_id"`
+			Tags        []string `json:"tags"`
 		} `json:"port"`
 	}
 	req.Port.Name = port.Name
 	req.Port.Description = port.Description
 	req.Port.NetworkId = port.NetworkId
+	req.Port.Tags = port.Tags
 
 	var expected struct {
 		Port neutron.PortV2 `json:"port"`

--- a/testservices/neutronservice/service_test.go
+++ b/testservices/neutronservice/service_test.go
@@ -641,12 +641,14 @@ func (s *NeutronSuite) TestAllPorts(c *gc.C) {
 			Name:      "one",
 			NetworkId: "a87cc70a-3e15-4acf-8205-9b711a3531b7",
 			TenantId:  s.service.TenantId,
+			Tags:      []string{"tag0", "tag1"},
 		},
 		{
 			Id:        "2",
 			Name:      "two",
 			NetworkId: "a87cc70a-3e15-4acf-8205-9b711a3531xx",
 			TenantId:  s.service.TenantId,
+			Tags:      []string{"tag2", "tag3"},
 		},
 	}
 
@@ -668,6 +670,7 @@ func (s *NeutronSuite) TestGetPort(c *gc.C) {
 		Name:        "port",
 		Description: "desc",
 		NetworkId:   "a87cc70a-3e15-4acf-8205-9b711a3531xx",
+		Tags:        []string{"tag0", "tag1"},
 	}
 	s.createPort(c, port)
 	defer s.deletePort(c, port)


### PR DESCRIPTION
In order to identify ports once created and to be able to filter
them using list ports, it's ideal to place tags on each port.

The code updates the port struct to add the tag and then goes
through the test harness to expect the tag field in the tests.

#### Reference

See the creation of ports documentation:
https://docs.openstack.org/api-ref/network/v2/index.html?expanded=create-port-detail#ports
