### PR TITLE
Expose device owner

### DIFF
--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -253,6 +253,7 @@ func (c *Client) DeleteFloatingIPV2(ipId string) error {
 type PortV2 struct {
 	Description         string           `json:"description,omitempty"`
 	DeviceId            string           `json:"device_id,omitempty"`
+	DeviceOwner         string           `json:"device_owner,omitempty"`
 	FixedIPs            []PortFixedIPsV2 `json:"fixed_ips,omitempty"`
 	Id                  string           `json:"id,omitempty"`
 	Name                string           `json:"name,omitempty"`


### PR DESCRIPTION
In order to understand whom owns the device (port in this case), so that
we can effectively remove a port that we own, we need to check the
ownership first.