### PR TITLE
Allow overloading of headers.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -94,6 +94,9 @@ type AuthenticatingClient interface {
 }
 
 // Option allows the adaptation of a client given new options.
+// Both client.Client and http.Client have Options. To allow isolation between
+// layers, we have separate options. If client.Client and http.Client want
+// different options they can do so, without causing conflict.
 type Option func(*options)
 
 type options struct {

--- a/http/client.go
+++ b/http/client.go
@@ -187,8 +187,8 @@ func NewWithTLSConfig(tlsConfig *tls.Config, options ...Option) *Client {
 	}
 }
 
-// GooseAgent returns the current client goose agent version.
-func GooseAgent() string {
+// gooseAgent returns the current client goose agent version.
+func gooseAgent() string {
 	return fmt.Sprintf("goose (%s)", goose.Version)
 }
 

--- a/http/client.go
+++ b/http/client.go
@@ -37,12 +37,18 @@ type HttpClient interface {
 	PostForm(url string, data url.Values) (resp *http.Response, err error)
 }
 
+// Option allows the adaptation of a http client given new options.
+// Both client.Client and http.Client have Options. To allow isolation between
+// layers, we have separate options. If client.Client and http.Client want
+// different options they can do so, without causing conflict.
 type Option func(*options)
 
 type options struct {
 	headersFunc HeadersFunc
 }
 
+// WithHeadersFunc allows passing in a new headers func for the http.Client
+// to execute for each request.
 func WithHeadersFunc(headersFunc HeadersFunc) Option {
 	return func(options *options) {
 		options.headersFunc = headersFunc

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -46,7 +46,7 @@ var _ = gc.Suite(&HTTPClientTestSuite{})
 
 func (s *HTTPClientTestSuite) assertHeaderValues(c *gc.C, token string) {
 	emptyHeaders := http.Header{}
-	headers := createHeaders(emptyHeaders, "content-type", token, true)
+	headers := DefaultHeaders("GET", emptyHeaders, "content-type", token, true)
 	contentTypes := []string{"content-type"}
 	headerData := map[string][]string{
 		"Content-Type": contentTypes, "Accept": contentTypes, "User-Agent": {gooseAgent()}}
@@ -71,7 +71,7 @@ func (s *HTTPClientTestSuite) TestCreateHeadersCopiesSupplied(c *gc.C) {
 	initialHeaders["Foo"] = []string{"Bar"}
 	contentType := contentTypeJSON
 	contentTypes := []string{contentType}
-	headers := createHeaders(initialHeaders, contentType, "", true)
+	headers := DefaultHeaders("GET", initialHeaders, contentType, "", true)
 	// it should not change the headers passed in
 	c.Assert(initialHeaders, gc.DeepEquals, http.Header{"Foo": []string{"Bar"}})
 	// The initial headers should be in the output

--- a/http/headers.go
+++ b/http/headers.go
@@ -1,0 +1,34 @@
+package http
+
+import "net/http"
+
+// HeadersFunc is type for aligning the creation of a series of client headers.
+type HeadersFunc = func(method string, headers http.Header, contentType, authToken string, hasPayload bool) http.Header
+
+// DefaultHeaders creates a set of http.Headers from the given arguments passed
+// in.
+// In this case it applies the headers passed in first, then sets the following:
+//  - X-Auth-Token
+//  - Content-Type
+//  - Accept
+//  - User-Agent
+//
+func DefaultHeaders(method string, extraHeaders http.Header, contentType, authToken string, payloadExists bool) http.Header {
+	headers := make(http.Header)
+	if extraHeaders != nil {
+		for header, values := range extraHeaders {
+			for _, value := range values {
+				headers.Add(header, value)
+			}
+		}
+	}
+	if authToken != "" {
+		headers.Set("X-Auth-Token", authToken)
+	}
+	if payloadExists {
+		headers.Add("Content-Type", contentType)
+	}
+	headers.Add("Accept", contentType)
+	headers.Add("User-Agent", GooseAgent())
+	return headers
+}

--- a/http/headers.go
+++ b/http/headers.go
@@ -14,7 +14,7 @@ type HeadersFunc = func(method string, headers http.Header, contentType, authTok
 //  - User-Agent
 //
 func DefaultHeaders(method string, extraHeaders http.Header, contentType, authToken string, payloadExists bool) http.Header {
-	headers := make(http.Header)
+	headers := BasicHeaders()
 	if extraHeaders != nil {
 		for header, values := range extraHeaders {
 			for _, value := range values {
@@ -29,6 +29,12 @@ func DefaultHeaders(method string, extraHeaders http.Header, contentType, authTo
 		headers.Add("Content-Type", contentType)
 	}
 	headers.Add("Accept", contentType)
-	headers.Add("User-Agent", GooseAgent())
+	return headers
+}
+
+// BasicHeaders constructs basic http.Headers with expected default values.
+func BasicHeaders() http.Header {
+	headers := make(http.Header)
+	headers.Add("User-Agent", gooseAgent())
 	return headers
 }

--- a/identity/legacy.go
+++ b/identity/legacy.go
@@ -17,39 +17,45 @@ func (l *Legacy) Auth(creds *Credentials) (*AuthDetails, error) {
 	if l.client == nil {
 		l.client = goosehttp.New()
 	}
+
 	request, err := http.NewRequest("GET", creds.URL, nil)
 	if err != nil {
 		return nil, err
 	}
 	request.Header.Set("X-Auth-User", creds.User)
 	request.Header.Set("X-Auth-Key", creds.Secrets)
+
 	response, err := l.client.Do(request)
 	if err != nil {
 		return nil, err
 	}
 	defer response.Body.Close()
+
 	if response.StatusCode != http.StatusNoContent && response.StatusCode != http.StatusOK {
 		content, _ := ioutil.ReadAll(response.Body)
 		return nil, fmt.Errorf("Failed to Authenticate (code %d %s): %s",
 			response.StatusCode, response.Status, content)
 	}
+
 	details := &AuthDetails{}
 	details.Token = response.Header.Get("X-Auth-Token")
 	if details.Token == "" {
 		return nil, gooseerrors.NewUnauthorisedf(nil, "", "Did not get valid Token from auth request")
 	}
 	details.RegionServiceURLs = make(map[string]ServiceURLs)
+
 	serviceURLs := make(ServiceURLs)
+
 	// Legacy authentication doesn't require a region so use "".
 	details.RegionServiceURLs[""] = serviceURLs
-	nova_url := response.Header.Get("X-Server-Management-Url")
-	serviceURLs["compute"] = nova_url
+	novaURL := response.Header.Get("X-Server-Management-Url")
+	serviceURLs["compute"] = novaURL
 
-	swift_url := response.Header.Get("X-Storage-Url")
-	if swift_url == "" {
+	swiftURL := response.Header.Get("X-Storage-Url")
+	if swiftURL == "" {
 		return nil, fmt.Errorf("Did not get valid swift management URL from auth request")
 	}
-	serviceURLs["object-store"] = swift_url
+	serviceURLs["object-store"] = swiftURL
 
 	return details, nil
 }

--- a/identity/legacy_test.go
+++ b/identity/legacy_test.go
@@ -16,10 +16,13 @@ var _ = gc.Suite(&LegacyTestSuite{})
 func (s *LegacyTestSuite) TestAuthAgainstServer(c *gc.C) {
 	service := identityservice.NewLegacy()
 	s.Mux.Handle("/", service)
+
 	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
 	service.SetManagementURL("http://management.test.invalid/url")
+
 	var l Authenticator = &Legacy{}
 	creds := Credentials{User: "joe-user", URL: s.Server.URL, Secrets: "secrets"}
+
 	auth, err := l.Auth(&creds)
 	c.Assert(err, gc.IsNil)
 	c.Assert(auth.Token, gc.Equals, userInfo.Token)
@@ -32,7 +35,9 @@ func (s *LegacyTestSuite) TestAuthAgainstServer(c *gc.C) {
 func (s *LegacyTestSuite) TestBadAuth(c *gc.C) {
 	service := identityservice.NewLegacy()
 	s.Mux.Handle("/", service)
+
 	_ = service.AddUser("joe-user", "secrets", "tenant", "default")
+
 	var l Authenticator = &Legacy{}
 	creds := Credentials{User: "joe-user", URL: s.Server.URL, Secrets: "bad-secrets"}
 	auth, err := l.Auth(&creds)

--- a/identity/live_test.go
+++ b/identity/live_test.go
@@ -40,8 +40,10 @@ func (s *LiveTests) TearDownTest(c *gc.C) {
 func (s *LiveTests) TestAuth(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
+
 	serviceURL, err := s.client.MakeServiceURL("compute", "v2", []string{})
 	c.Assert(err, gc.IsNil)
+
 	_, err = url.Parse(serviceURL)
 	c.Assert(err, gc.IsNil)
 }

--- a/identity/local_test.go
+++ b/identity/local_test.go
@@ -64,8 +64,10 @@ func (s *localLiveSuite) TearDownTest(c *gc.C) {
 func (s *localLiveSuite) TestProductStreamsEndpoint(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
+
 	serviceURL, err := s.client.MakeServiceURL("product-streams", "", nil)
 	c.Assert(err, gc.IsNil)
+
 	_, err = url.Parse(serviceURL)
 	c.Assert(err, gc.IsNil)
 	c.Assert(strings.HasSuffix(serviceURL, "/imagemetadata"), gc.Equals, true)
@@ -74,8 +76,10 @@ func (s *localLiveSuite) TestProductStreamsEndpoint(c *gc.C) {
 func (s *localLiveSuite) TestJujuToolsEndpoint(c *gc.C) {
 	err := s.client.Authenticate()
 	c.Assert(err, gc.IsNil)
+
 	serviceURL, err := s.client.MakeServiceURL("juju-tools", "", nil)
 	c.Assert(err, gc.IsNil)
+
 	_, err = url.Parse(serviceURL)
 	c.Assert(err, gc.IsNil)
 }

--- a/identity/userpass_test.go
+++ b/identity/userpass_test.go
@@ -16,9 +16,13 @@ var _ = gc.Suite(&UserPassTestSuite{})
 func (s *UserPassTestSuite) TestAuthAgainstServer(c *gc.C) {
 	service := identityservice.NewUserPass()
 	service.SetupHTTP(s.Mux)
+
 	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
+
 	var l Authenticator = &UserPass{}
+
 	creds := Credentials{User: "joe-user", URL: s.Server.URL + "/tokens", Secrets: "secrets"}
+
 	auth, err := l.Auth(&creds)
 	c.Assert(err, gc.IsNil)
 	c.Assert(auth.Token, gc.Equals, userInfo.Token)
@@ -29,7 +33,9 @@ func (s *UserPassTestSuite) TestAuthAgainstServer(c *gc.C) {
 func (s *UserPassTestSuite) TestRegionMatch(c *gc.C) {
 	service := identityservice.NewUserPass()
 	service.SetupHTTP(s.Mux)
+
 	userInfo := service.AddUser("joe-user", "secrets", "tenant", "default")
+
 	serviceDef := identityservice.V2Service{
 		Name: "swift",
 		Type: "object-store",
@@ -37,6 +43,7 @@ func (s *UserPassTestSuite) TestRegionMatch(c *gc.C) {
 			{PublicURL: "http://swift", Region: "RegionOne"},
 		}}
 	service.AddService(identityservice.Service{V2: serviceDef})
+
 	serviceDef = identityservice.V2Service{
 		Name: "nova",
 		Type: "compute",
@@ -44,6 +51,7 @@ func (s *UserPassTestSuite) TestRegionMatch(c *gc.C) {
 			{PublicURL: "http://nova", Region: "zone1.RegionOne"},
 		}}
 	service.AddService(identityservice.Service{V2: serviceDef})
+
 	serviceDef = identityservice.V2Service{
 		Name: "nova",
 		Type: "compute",
@@ -58,7 +66,9 @@ func (s *UserPassTestSuite) TestRegionMatch(c *gc.C) {
 		Secrets: "secrets",
 		Region:  "zone1.RegionOne",
 	}
+
 	var l Authenticator = &UserPass{}
+
 	auth, err := l.Auth(&creds)
 	c.Assert(err, gc.IsNil)
 	c.Assert(auth.RegionServiceURLs["RegionOne"]["object-store"], gc.Equals, "http://swift")

--- a/neutron/clientheaders.go
+++ b/neutron/clientheaders.go
@@ -15,12 +15,11 @@ import (
 //  - User-Agent
 //
 func NeutronHeaders(method string, extraHeaders http.Header, contentType, authToken string, payloadExists bool) http.Header {
-	headers := make(http.Header)
+	headers := goosehttp.BasicHeaders()
 
 	if authToken != "" {
 		headers.Set("X-Auth-Token", authToken)
 	}
-	headers.Add("User-Agent", goosehttp.GooseAgent())
 
 	// Officially we should also take into account the method, as we should not
 	// be applying this to every request.
@@ -28,17 +27,22 @@ func NeutronHeaders(method string, extraHeaders http.Header, contentType, authTo
 		headers.Add("Content-Type", contentType)
 	}
 
-	// POST allows Content-Type, Accept
-	// PUT allows Content-Type, Accept
-	// GET allows Accept
-	// PATCH allows Content-Type, Accept
-	// HEAD allows
-	// OPTIONS allows
-	// DELETE allows
+	// According to the REST specs, the following should be considered the
+	// correct implementation of requests. Openstack implementation follow
+	// these specs and will return errors if certain headers are pressent.
+	//
+	// POST allows:    [Content-Type, Accept]
+	// PUT allows:     [Content-Type, Accept]
+	// GET allows:     [Accept]
+	// PATCH allows:   [Content-Type, Accept]
+	// HEAD allows:    []
+	// OPTIONS allows: []
+	// DELETE allows:  []
+	// COPY allows:    []
 
 	var ignoreAccept bool
 	switch method {
-	case "DELETE", "HEAD", "OPTIONS":
+	case "DELETE", "HEAD", "OPTIONS", "COPY":
 		ignoreAccept = true
 	}
 

--- a/neutron/clientheaders.go
+++ b/neutron/clientheaders.go
@@ -1,0 +1,59 @@
+package neutron
+
+import (
+	"net/http"
+
+	goosehttp "gopkg.in/goose.v2/http"
+)
+
+// NeutronHeaders creates a set of http.Headers from the given arguments passed
+// in.
+// In this case it applies the headers passed in first, then sets the following:
+//  - X-Auth-Token
+//  - Content-Type
+//  - Accept
+//  - User-Agent
+//
+func NeutronHeaders(method string, extraHeaders http.Header, contentType, authToken string, payloadExists bool) http.Header {
+	headers := make(http.Header)
+
+	if authToken != "" {
+		headers.Set("X-Auth-Token", authToken)
+	}
+	headers.Add("User-Agent", goosehttp.GooseAgent())
+
+	// Officially we should also take into account the method, as we should not
+	// be applying this to every request.
+	if payloadExists {
+		headers.Add("Content-Type", contentType)
+	}
+
+	// POST allows Content-Type, Accept
+	// PUT allows Content-Type, Accept
+	// GET allows Accept
+	// PATCH allows Content-Type, Accept
+	// HEAD allows
+	// OPTIONS allows
+	// DELETE allows
+
+	var ignoreAccept bool
+	switch method {
+	case "DELETE", "HEAD", "OPTIONS":
+		ignoreAccept = true
+	}
+
+	if !ignoreAccept {
+		headers.Add("Accept", contentType)
+	}
+
+	// Now apply the passed in headers to the newly created headers.
+	if extraHeaders != nil {
+		for header, values := range extraHeaders {
+			for _, value := range values {
+				headers.Add(header, value)
+			}
+		}
+	}
+
+	return headers
+}

--- a/neutron/clientheaders_test.go
+++ b/neutron/clientheaders_test.go
@@ -13,7 +13,7 @@ type clientHeaderSuite struct{}
 var _ = gc.Suite(&clientHeaderSuite{})
 
 func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
-	lift := func(m map[string]string) http.Header {
+	makeHeaders := func(m map[string]string) http.Header {
 		headers := goosehttp.BasicHeaders()
 		for k, v := range m {
 			headers.Add(k, v)
@@ -35,7 +35,7 @@ func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
 		{
 			name:   "test GET with empty args",
 			method: "GET",
-			expected: lift(map[string]string{
+			expected: makeHeaders(map[string]string{
 				"Accept": "",
 			}),
 		},
@@ -47,7 +47,7 @@ func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
 			method:        "GET",
 			contentType:   "application/json",
 			payloadExists: true,
-			expected: lift(map[string]string{
+			expected: makeHeaders(map[string]string{
 				"Content-Type": "application/json",
 				"Accept":       "application/json",
 			}),
@@ -61,7 +61,7 @@ func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
 			method:        method,
 			contentType:   "application/json",
 			payloadExists: true,
-			expected: lift(map[string]string{
+			expected: makeHeaders(map[string]string{
 				"Content-Type": "application/json",
 				"Accept":       "application/json",
 			}),
@@ -69,7 +69,7 @@ func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
 			name:        fmt.Sprintf("test %s", method),
 			method:      method,
 			contentType: "application/json",
-			expected: lift(map[string]string{
+			expected: makeHeaders(map[string]string{
 				"Accept": "application/json",
 			}),
 		})
@@ -82,14 +82,14 @@ func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
 			method:        method,
 			contentType:   "application/json",
 			payloadExists: true,
-			expected: lift(map[string]string{
+			expected: makeHeaders(map[string]string{
 				"Content-Type": "application/json",
 			}),
 		}, test{
 			name:        fmt.Sprintf("test %s", method),
 			method:      method,
 			contentType: "application/json",
-			expected:    lift(map[string]string{}),
+			expected:    makeHeaders(map[string]string{}),
 		})
 	}
 

--- a/neutron/clientheaders_test.go
+++ b/neutron/clientheaders_test.go
@@ -1,0 +1,102 @@
+package neutron
+
+import (
+	"fmt"
+	"net/http"
+
+	gc "gopkg.in/check.v1"
+	goosehttp "gopkg.in/goose.v2/http"
+)
+
+type clientHeaderSuite struct{}
+
+var _ = gc.Suite(&clientHeaderSuite{})
+
+func (s *clientHeaderSuite) TestNeutronHeaders(c *gc.C) {
+	lift := func(m map[string]string) http.Header {
+		headers := goosehttp.BasicHeaders()
+		for k, v := range m {
+			headers.Add(k, v)
+		}
+		return headers
+	}
+
+	type test struct {
+		name          string
+		method        string
+		headers       http.Header
+		contentType   string
+		authToken     string
+		payloadExists bool
+		expected      http.Header
+	}
+
+	tests := []test{
+		{
+			name:   "test GET with empty args",
+			method: "GET",
+			expected: lift(map[string]string{
+				"Accept": "",
+			}),
+		},
+		{
+			// TODO (stickupkid): This test is actually wrong, it shouldn't
+			// return a Content-Type for GET, but to keep backwards
+			// compatibility, we accept this.
+			name:          "test GET",
+			method:        "GET",
+			contentType:   "application/json",
+			payloadExists: true,
+			expected: lift(map[string]string{
+				"Content-Type": "application/json",
+				"Accept":       "application/json",
+			}),
+		},
+	}
+
+	// Test that Content-Type and Accept are correctly applied.
+	for _, method := range []string{"POST", "PUT", "PATCH"} {
+		tests = append(tests, test{
+			name:          fmt.Sprintf("test %s", method),
+			method:        method,
+			contentType:   "application/json",
+			payloadExists: true,
+			expected: lift(map[string]string{
+				"Content-Type": "application/json",
+				"Accept":       "application/json",
+			}),
+		}, test{
+			name:        fmt.Sprintf("test %s", method),
+			method:      method,
+			contentType: "application/json",
+			expected: lift(map[string]string{
+				"Accept": "application/json",
+			}),
+		})
+	}
+
+	// Test that Content-Type is correctly applied, but not Accept.
+	for _, method := range []string{"HEAD", "OPTIONS", "DELETE", "COPY"} {
+		tests = append(tests, test{
+			name:          fmt.Sprintf("test %s", method),
+			method:        method,
+			contentType:   "application/json",
+			payloadExists: true,
+			expected: lift(map[string]string{
+				"Content-Type": "application/json",
+			}),
+		}, test{
+			name:        fmt.Sprintf("test %s", method),
+			method:      method,
+			contentType: "application/json",
+			expected:    lift(map[string]string{}),
+		})
+	}
+
+	for i, test := range tests {
+		c.Logf("test: %d, %s", i, test.name)
+
+		got := NeutronHeaders(test.method, test.headers, test.contentType, test.authToken, test.payloadExists)
+		c.Assert(got, gc.DeepEquals, test.expected)
+	}
+}

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -253,6 +253,7 @@ func (c *Client) DeleteFloatingIPV2(ipId string) error {
 type PortV2 struct {
 	Description         string           `json:"description,omitempty"`
 	DeviceId            string           `json:"device_id,omitempty"`
+	DeviceOwner         string           `json:"device_owner,omitempty"`
 	FixedIPs            []PortFixedIPsV2 `json:"fixed_ips,omitempty"`
 	Id                  string           `json:"id,omitempty"`
 	Name                string           `json:"name,omitempty"`

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -75,7 +75,9 @@ type Client struct {
 
 // New creates a new Client.
 func New(client client.Client) *Client {
-	return &Client{client}
+	return &Client{
+		client: client,
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -251,13 +253,14 @@ func (c *Client) DeleteFloatingIPV2(ipId string) error {
 
 // PortV2 describes a defined network for administrating a port.
 type PortV2 struct {
+	AdminStateUp        bool             `json:"admin_state_up,omitempty"`
 	Description         string           `json:"description,omitempty"`
 	DeviceId            string           `json:"device_id,omitempty"`
 	DeviceOwner         string           `json:"device_owner,omitempty"`
 	FixedIPs            []PortFixedIPsV2 `json:"fixed_ips,omitempty"`
 	Id                  string           `json:"id,omitempty"`
 	Name                string           `json:"name,omitempty"`
-	NetworkId           string           `json:"network_id"`
+	NetworkId           string           `json:"network_id,omitempty"`
 	PortSecurityEnabled bool             `json:"port_security_enabled,omitempty"`
 	SecurityGroups      []string         `json:"security_groups,omitempty"`
 	Status              string           `json:"status,omitempty"`


### PR DESCRIPTION
The following changes expose the http headers to us as a library user
can alter them if required. This happens to be the case for juju, where
we want to ensure that some headers are not set.

This is a halfway house as the real fix is to create a factor method for
handling the different client constructors. Then you can pass in a
header method to the factory to then create them. Unfortunately, we're
late in the cycle and doing that at this late stage is _very_ risky. So
let's take the more moderate approach and come back to this for V3 of
goose.

---

It should be noted this is backwards compatible with existing code, as
we're using optional method parameters.