### PR TITLE
Add project domain id to identity credentials

### DIFF
--- a/identity/identity.go
+++ b/identity/identity.go
@@ -62,16 +62,17 @@ type AuthDetails struct {
 // Credentials defines necessary parameters for authentication.
 // TODO - Tenant is deprecated, migrate attribute names to Project.
 type Credentials struct {
-	URL           string // The URL to authenticate against
-	User          string // The username to authenticate as
-	Secrets       string // The secrets to pass
-	Region        string // Region to send requests to
-	TenantName    string `credentials:"optional"` // The project name for this connection
-	TenantID      string `credentials:"optional"` // The project ID for this connection
-	Version       int    `credentials:"optional"` // The Keystone version
-	Domain        string `credentials:"optional"` // The domain for authorization (new in keystone v3)
-	UserDomain    string `credentials:"optional"` // The owning domain for this user (new in keystone v3)
-	ProjectDomain string `credentials:"optional"` // The project domain for authorization (new in keystone v3)
+	URL             string // The URL to authenticate against
+	User            string // The username to authenticate as
+	Secrets         string // The secrets to pass
+	Region          string // Region to send requests to
+	TenantName      string `credentials:"optional"` // The project name for this connection
+	TenantID        string `credentials:"optional"` // The project ID for this connection
+	Version         int    `credentials:"optional"` // The Keystone version
+	Domain          string `credentials:"optional"` // The domain for authorization (new in keystone v3)
+	UserDomain      string `credentials:"optional"` // The owning domain for this user (new in keystone v3)
+	ProjectDomain   string `credentials:"optional"` // The project domain for authorization (new in keystone v3)
+	ProjectDomainID string `credentials:"optional"` // The project domain id for authorization (new in keystone v3)
 }
 
 // Authenticator is implemented by each authentication method.
@@ -147,6 +148,9 @@ var (
 	CredEnvProjectDomainName = []string{
 		"OS_PROJECT_DOMAIN_NAME",
 	}
+        CredEnvProjectDomainID = []string{
+                "OS_PROJECT_DOMAIN_ID",
+        }
 	CredEnvUserDomainName = []string{
 		"OS_USER_DOMAIN_NAME",
 	}
@@ -159,15 +163,16 @@ var (
 // environment variables.
 func CredentialsFromEnv() (*Credentials, error) {
 	cred := &Credentials{
-		URL:           getConfig(CredEnvAuthURL),
-		User:          getConfig(CredEnvUser),
-		Secrets:       getConfig(CredEnvSecrets),
-		Region:        getConfig(CredEnvRegion),
-		TenantName:    getConfig(CredEnvTenantName),
-		TenantID:      getConfig(CredEnvTenantID),
-		Domain:        getConfig(CredEnvDomainName),
-		UserDomain:    getConfig(CredEnvUserDomainName),
-		ProjectDomain: getConfig(CredEnvProjectDomainName),
+		URL:             getConfig(CredEnvAuthURL),
+		User:            getConfig(CredEnvUser),
+		Secrets:         getConfig(CredEnvSecrets),
+		Region:          getConfig(CredEnvRegion),
+		TenantName:      getConfig(CredEnvTenantName),
+		TenantID:        getConfig(CredEnvTenantID),
+		Domain:          getConfig(CredEnvDomainName),
+		UserDomain:      getConfig(CredEnvUserDomainName),
+		ProjectDomain:   getConfig(CredEnvProjectDomainName),
+		ProjectDomainID: getConfig(CredEnvProjectDomainID),
 	}
 	defaultDomain := getConfig(CredEnvDefaultDomainName)
 	if defaultDomain != "" {

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -86,6 +86,7 @@ func (s *CredentialsTestSuite) TestCompleteCredentialsFromEnvValid(c *gc.C) {
 		"OS_REGION_NAME":         "region",
 		"OS_DOMAIN_NAME":         "domain-name",
 		"OS_PROJECT_DOMAIN_NAME": "project-domain-name",
+		"OS_PROJECT_DOMAIN_ID":   "project-domain-id",
 		"OS_USER_DOMAIN_NAME":    "user-domain-name",
 		// ignored because user and project domains set
 		"OS_DEFAULT_DOMAIN_NAME": "default-domain-name",
@@ -102,6 +103,7 @@ func (s *CredentialsTestSuite) TestCompleteCredentialsFromEnvValid(c *gc.C) {
 	c.Check(creds.TenantName, gc.Equals, "tenant-name")
 	c.Check(creds.Domain, gc.Equals, "domain-name")
 	c.Check(creds.ProjectDomain, gc.Equals, "project-domain-name")
+	c.Check(creds.ProjectDomainID, gc.Equals, "project-domain-id")
 	c.Check(creds.UserDomain, gc.Equals, "user-domain-name")
 }
 

--- a/identity/v3userpass.go
+++ b/identity/v3userpass.go
@@ -85,7 +85,8 @@ func (u *V3UserPass) Auth(creds *Credentials) (*AuthDetails, error) {
 		userDomain = "default"
 	}
 	projectDomain := creds.ProjectDomain
-	if projectDomain == "" {
+	projectDomainID := creds.ProjectDomainID
+	if (projectDomain == "") && (projectDomainID == "") {
 		projectDomain = "default"
 	}
 	auth := v3AuthWrapper{
@@ -109,6 +110,7 @@ func (u *V3UserPass) Auth(creds *Credentials) (*AuthDetails, error) {
 			Project: &v3AuthProject{
 				Domain: &v3AuthDomain{
 					Name: projectDomain,
+					ID:   projectDomainID,
 				},
 				Name: creds.TenantName,
 				ID:   creds.TenantID,


### PR DESCRIPTION
openrc downloaded from OpenStack horizon for a non-admin
user has OS_PROJECT_DOMAIN_ID set but not OS_PROJECT_DOMAIN_NAME.

Project domain ID details are added in Credentials structure.

Fixes: #88