### PR TITLE
Logging: Default logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Install the package with:
 
 Import it with:
 
-    import "github.com/go-goose/goose/v3/<package>"
+    import "github.com/go-goose/goose/v4/<package>"
 
 Example:
 
-    import "github.com/go-goose/goose/v3/client"
+    import "github.com/go-goose/goose/v4/client"
 
 and use _client_ as the package name inside the code.
 The same applies to the other sub-packages: _nova_, _switft_, etc.

--- a/cinder/autogenerated_client.go
+++ b/cinder/autogenerated_client.go
@@ -16,9 +16,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/go-goose/goose/v3/client"
-	gooseerrors "github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	gooseerrors "github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // RequestHandlerFn specifies a function signature which wadl2go will

--- a/cinder/client.go
+++ b/cinder/client.go
@@ -10,8 +10,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // Basic returns a basic Cinder client which will handle authorization

--- a/cinder/live_test.go
+++ b/cinder/live_test.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/identity"
 	gc "gopkg.in/check.v1"
 )
 

--- a/client/apiversion.go
+++ b/client/apiversion.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/logging"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/logging"
 )
 
 // ApiVersion represents choices.id from the openstack

--- a/client/client.go
+++ b/client/client.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/juju/collections/set"
 
-	gooseerrors "github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/internal/gooseio"
-	"github.com/go-goose/goose/v3/logging"
-	goosesync "github.com/go-goose/goose/v3/sync"
+	gooseerrors "github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/internal/gooseio"
+	"github.com/go-goose/goose/v4/logging"
+	goosesync "github.com/go-goose/goose/v4/sync"
 )
 
 const (

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack (Canonistack) tests")

--- a/client/export_test.go
+++ b/client/export_test.go
@@ -3,9 +3,9 @@ package client
 import (
 	"time"
 
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/logging"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/logging"
 )
 
 type AuthCleanup func()

--- a/client/live_test.go
+++ b/client/live_test.go
@@ -3,9 +3,9 @@ package client_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	gooseerrors "github.com/go-goose/goose/v3/errors"
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/client"
+	gooseerrors "github.com/go-goose/goose/v4/errors"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 func registerOpenStackTests(cred *identity.Credentials, authModes []identity.AuthMode) {

--- a/client/local_test.go
+++ b/client/local_test.go
@@ -10,18 +10,18 @@ import (
 	"sync"
 	"time"
 
-	"github.com/juju/loggo"
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/logging"
-	"github.com/go-goose/goose/v3/swift"
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/openstackservice"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/logging"
+	"github.com/go-goose/goose/v4/swift"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/openstackservice"
+	"github.com/juju/loggo"
 )
 
 func registerLocalTests(authModes []identity.AuthMode) {
@@ -251,15 +251,16 @@ func (s *localLiveSuite) TestAuthenticationTimeout(c *gc.C) {
 	auth := s.doNewAuthenticator(c, 0, "3003")
 	client.SetAuthenticator(cl, auth)
 
-	var err error
-	err = cl.Authenticate()
+	err := cl.Authenticate()
 	// Wake up the authenticator after we have timed out.
 	auth.authStart <- struct{}{}
 	c.Assert(errors.IsTimeout(err), gc.Equals, true)
 }
 
 func (s *localLiveSuite) assertAuthenticationSuccess(c *gc.C, port string) client.AuthenticatingClient {
-	cl := client.NewClient(s.cred, s.authMode, logging.LoggoLogger{loggo.GetLogger("goose.client")})
+	cl := client.NewClient(s.cred, s.authMode, logging.DebugLoggerAdapater{
+		Logger: loggo.GetLogger("goose.client"),
+	})
 	cl.SetRequiredServiceTypes([]string{"compute"})
 	defer client.SetAuthenticationTimeout(2 * time.Millisecond)()
 	auth := s.doNewAuthenticator(c, 1, port)

--- a/client/mock_test.go
+++ b/client/mock_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/golang/mock/gomock"
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/client/mocks"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/client/mocks"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 type localMockSuite struct {

--- a/client/mocks/auth.go
+++ b/client/mocks/auth.go
@@ -5,7 +5,7 @@
 package mocks
 
 import (
-	identity "github.com/go-goose/goose/v3/identity"
+	identity "github.com/go-goose/goose/v4/identity"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )

--- a/client/mocks/httpclient.go
+++ b/client/mocks/httpclient.go
@@ -5,8 +5,8 @@
 package mocks
 
 import (
-	http "github.com/go-goose/goose/v3/http"
-	logging "github.com/go-goose/goose/v3/logging"
+	http "github.com/go-goose/goose/v4/http"
+	logging "github.com/go-goose/goose/v4/logging"
 	gomock "github.com/golang/mock/gomock"
 	io "io"
 	http0 "net/http"

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/errors"
+	"github.com/go-goose/goose/v4/errors"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }

--- a/glance/glance.go
+++ b/glance/glance.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // API URL parts.

--- a/glance/glance_test.go
+++ b/glance/glance_test.go
@@ -6,9 +6,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/glance"
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/glance"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 func Test(t *testing.T) { gc.TestingT(t) }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-goose/goose/v3
+module github.com/go-goose/goose/v4
 
 go 1.14
 

--- a/http/client.go
+++ b/http/client.go
@@ -14,10 +14,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-goose/goose/v3"
-	"github.com/go-goose/goose/v3/errors"
-	"github.com/go-goose/goose/v3/internal/gooseio"
-	"github.com/go-goose/goose/v3/logging"
+	"github.com/go-goose/goose/v4"
+	"github.com/go-goose/goose/v4/errors"
+	"github.com/go-goose/goose/v4/internal/gooseio"
+	"github.com/go-goose/goose/v4/logging"
 )
 
 const (

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -13,7 +13,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
 )
 
 type LoopingHTTPSuite struct {

--- a/identity/identity.go
+++ b/identity/identity.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/logging"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/logging"
 )
 
 // AuthMode defines the authentication method to use (see Auth*

--- a/identity/identity_test.go
+++ b/identity/identity_test.go
@@ -5,8 +5,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/testing/envsuite"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/testing/envsuite"
 )
 
 type CredentialsTestSuite struct {

--- a/identity/keypair.go
+++ b/identity/keypair.go
@@ -1,7 +1,7 @@
 package identity
 
 import (
-	goosehttp "github.com/go-goose/goose/v3/http"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // KeyPair allows OpenStack cloud authentication using an access and

--- a/identity/keystone.go
+++ b/identity/keystone.go
@@ -3,8 +3,8 @@ package identity
 import (
 	"fmt"
 
-	gooseerrors "github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	gooseerrors "github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 type endpoint struct {

--- a/identity/legacy.go
+++ b/identity/legacy.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	gooseerrors "github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	gooseerrors "github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 type Legacy struct {

--- a/identity/legacy_test.go
+++ b/identity/legacy_test.go
@@ -3,8 +3,8 @@ package identity
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 type LegacyTestSuite struct {

--- a/identity/live_test.go
+++ b/identity/live_test.go
@@ -5,8 +5,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 func registerOpenStackTests(cred *identity.Credentials, authMode identity.AuthMode) {

--- a/identity/local_test.go
+++ b/identity/local_test.go
@@ -6,8 +6,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/testservices/openstackservice"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/testservices/openstackservice"
 )
 
 func registerLocalTests(authMode identity.AuthMode) {

--- a/identity/setup_test.go
+++ b/identity/setup_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack (Canonistack) tests")

--- a/identity/userpass.go
+++ b/identity/userpass.go
@@ -1,7 +1,7 @@
 package identity
 
 import (
-	goosehttp "github.com/go-goose/goose/v3/http"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 type passwordCredentials struct {

--- a/identity/userpass_test.go
+++ b/identity/userpass_test.go
@@ -3,8 +3,8 @@ package identity
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 type UserPassTestSuite struct {

--- a/identity/v3userpass.go
+++ b/identity/v3userpass.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"time"
 
-	gooseerrors "github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	gooseerrors "github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // v3AuthWrapper wraps the v3AuthRequest to perform v3 authentication.

--- a/identity/v3userpass_test.go
+++ b/identity/v3userpass_test.go
@@ -3,9 +3,9 @@ package identity
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 type V3UserPassTestSuite struct {

--- a/internal/gooseio/seekable_test.go
+++ b/internal/gooseio/seekable_test.go
@@ -12,7 +12,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/internal/gooseio"
+	"github.com/go-goose/goose/v4/internal/gooseio"
 )
 
 type getReqReaderSuite struct{}

--- a/internal/httpfile/httpfile_test.go
+++ b/internal/httpfile/httpfile_test.go
@@ -14,7 +14,7 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/go-goose/goose/v3/internal/httpfile"
+	"github.com/go-goose/goose/v4/internal/httpfile"
 	gc "gopkg.in/check.v1"
 )
 

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -5,16 +5,12 @@ package logging
 
 import (
 	"log"
-
-	"github.com/juju/loggo"
 )
 
 // CompatLogger is a minimal logging interface that may be provided
 // when constructing a goose Client to log requests and responses,
 // retaining compatibility with the old *log.Logger that was
 // previously depended upon directly.
-//
-// TODO(axw) in goose.v3, drop this and use loggo.Logger directly.
 type CompatLogger interface {
 	// Printf prints a log message. Arguments are handled
 	// in the/ manner of fmt.Printf.
@@ -29,17 +25,23 @@ type Logger interface {
 	Tracef(format string, v ...interface{})
 }
 
-// LoggoLogger is a logger that may be provided when constructing
+// DebugLogger represents any logger that offers a Debugf method which takes a
+// format and a series of optional objects for logging.
+type DebugLogger interface {
+	Debugf(format string, v ...interface{})
+}
+
+// DebugLoggerAdapater is a logger that may be provided when constructing
 // a goose Client to log requests and responses. Users must
 // provide a CompatLogger, which will be upgraded to Logger
 // if provided.
-type LoggoLogger struct {
-	loggo.Logger
+type DebugLoggerAdapater struct {
+	Logger DebugLogger
 }
 
 // Printf is part of the CompatLogger interface.
-func (l LoggoLogger) Printf(format string, v ...interface{}) {
-	l.Debugf(format, v...)
+func (l DebugLoggerAdapater) Printf(format string, v ...interface{}) {
+	l.Logger.Debugf(format, v...)
 }
 
 // CompatLoggerAdapter is a type wrapping CompatLogger, implementing

--- a/neutron/clientheaders.go
+++ b/neutron/clientheaders.go
@@ -3,7 +3,7 @@ package neutron
 import (
 	"net/http"
 
-	goosehttp "github.com/go-goose/goose/v3/http"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // NeutronHeaders creates a set of http.Headers from the given arguments passed

--- a/neutron/clientheaders_test.go
+++ b/neutron/clientheaders_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	goosehttp "github.com/go-goose/goose/v3/http"
+	goosehttp "github.com/go-goose/goose/v4/http"
 	gc "gopkg.in/check.v1"
 )
 

--- a/neutron/gbp.go
+++ b/neutron/gbp.go
@@ -12,9 +12,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 const (

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -5,9 +5,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/neutron"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/neutron"
 )
 
 func registerOpenStackTests(cred *identity.Credentials) {

--- a/neutron/local_test.go
+++ b/neutron/local_test.go
@@ -5,12 +5,12 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/openstackservice"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/openstackservice"
 )
 
 func registerLocalTests() {

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 const (

--- a/neutron/neutron_test.go
+++ b/neutron/neutron_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack tests")

--- a/nova/deprecated.go
+++ b/nova/deprecated.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // The following API requests found in this file are officially deprecated by

--- a/nova/json_test.go
+++ b/nova/json_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/nova"
+	"github.com/go-goose/goose/v4/nova"
 )
 
 type JsonSuite struct {

--- a/nova/live_test.go
+++ b/nova/live_test.go
@@ -9,10 +9,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/nova"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/nova"
 )
 
 const (

--- a/nova/local_test.go
+++ b/nova/local_test.go
@@ -9,15 +9,15 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/openstackservice"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/openstackservice"
 )
 
 func registerLocalTests() {

--- a/nova/networks.go
+++ b/nova/networks.go
@@ -9,9 +9,9 @@
 package nova
 
 import (
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 const (

--- a/nova/nova.go
+++ b/nova/nova.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
 )
 
 // API URL parts.

--- a/nova/nova_test.go
+++ b/nova/nova_test.go
@@ -8,7 +8,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 // instanceDetails specify parameters used to start a test machine for the live tests.

--- a/swift/live_test.go
+++ b/swift/live_test.go
@@ -10,10 +10,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/swift"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/swift"
 )
 
 func registerOpenStackTests(cred *identity.Credentials) {

--- a/swift/local_test.go
+++ b/swift/local_test.go
@@ -5,9 +5,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/openstackservice"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/openstackservice"
 )
 
 func registerLocalTests() {

--- a/swift/swift.go
+++ b/swift/swift.go
@@ -12,10 +12,10 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/errors"
-	goosehttp "github.com/go-goose/goose/v3/http"
-	"github.com/go-goose/goose/v3/internal/httpfile"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/errors"
+	goosehttp "github.com/go-goose/goose/v4/http"
+	"github.com/go-goose/goose/v4/internal/httpfile"
 )
 
 // Client provides a means to access the OpenStack Object Storage Service.

--- a/swift/swift_test.go
+++ b/swift/swift_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/identity"
+	"github.com/go-goose/goose/v4/identity"
 )
 
 var live = flag.Bool("live", false, "Include live OpenStack (Canonistack) tests")

--- a/testservices/cmd/main.go
+++ b/testservices/cmd/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/juju/gnuflag"
 
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 type userInfo struct {

--- a/testservices/identityservice/keypair.go
+++ b/testservices/identityservice/keypair.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/go-goose/goose/v3/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/hook"
 )
 
 // Implement the v2 Key Pair form of identity based on Keystone

--- a/testservices/identityservice/keypair_test.go
+++ b/testservices/identityservice/keypair_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
 )
 
 type KeyPairSuite struct {

--- a/testservices/identityservice/legacy_test.go
+++ b/testservices/identityservice/legacy_test.go
@@ -6,7 +6,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
 )
 
 type LegacySuite struct {

--- a/testservices/identityservice/service_test.go
+++ b/testservices/identityservice/service_test.go
@@ -3,7 +3,7 @@ package identityservice
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
 )
 
 // All tests in the IdentityServiceSuite run against each IdentityService

--- a/testservices/identityservice/userpass.go
+++ b/testservices/identityservice/userpass.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/go-goose/goose/v3/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/hook"
 )
 
 // Implement the v2 User Pass form of identity (Keystone)

--- a/testservices/identityservice/userpass_test.go
+++ b/testservices/identityservice/userpass_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
 )
 
 type UserPassSuite struct {

--- a/testservices/identityservice/v3userpass.go
+++ b/testservices/identityservice/v3userpass.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-goose/goose/v3/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/hook"
 )
 
 // V3UserPassRequest Implement the v3 User Pass form of identity (Keystone)

--- a/testservices/identityservice/v3userpass_test.go
+++ b/testservices/identityservice/v3userpass_test.go
@@ -9,7 +9,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
 )
 
 type V3UserPassSuite struct {

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -8,9 +8,9 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testservices"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testservices"
 )
 
 type NeutronModel struct {

--- a/testservices/neutronservice/service.go
+++ b/testservices/neutronservice/service.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
 )
 
 var _ testservices.HttpService = (*Neutron)(nil)

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -13,9 +13,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 const (

--- a/testservices/neutronservice/service_http_test.go
+++ b/testservices/neutronservice/service_http_test.go
@@ -13,10 +13,10 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
 )
 
 type NeutronHTTPSuite struct {

--- a/testservices/neutronservice/service_test.go
+++ b/testservices/neutronservice/service_test.go
@@ -7,8 +7,8 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
 )
 
 type NeutronSuite struct {

--- a/testservices/neutronservice/setup_test.go
+++ b/testservices/neutronservice/setup_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/neutron"
+	"github.com/go-goose/goose/v4/neutron"
 )
 
 func Test(t *testing.T) {

--- a/testservices/novaservice/service.go
+++ b/testservices/novaservice/service.go
@@ -10,11 +10,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-goose/goose/v3/errors"
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/errors"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
 )
 
 var _ testservices.HttpService = (*Nova)(nil)

--- a/testservices/novaservice/service_http.go
+++ b/testservices/novaservice/service_http.go
@@ -15,10 +15,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-goose/goose/v3/neutron"
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/neutron"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 const authToken = "X-Auth-Token"

--- a/testservices/novaservice/service_http_test.go
+++ b/testservices/novaservice/service_http_test.go
@@ -14,11 +14,11 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
 )
 
 type NovaHTTPSuite struct {

--- a/testservices/novaservice/service_test.go
+++ b/testservices/novaservice/service_test.go
@@ -7,9 +7,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
 )
 
 type NovaSuite struct {

--- a/testservices/novaservice/setup_test.go
+++ b/testservices/novaservice/setup_test.go
@@ -5,7 +5,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/nova"
+	"github.com/go-goose/goose/v4/nova"
 )
 
 func Test(t *testing.T) {

--- a/testservices/openstackservice/openstack.go
+++ b/testservices/openstackservice/openstack.go
@@ -9,12 +9,12 @@ import (
 
 	"crypto/x509"
 
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
-	"github.com/go-goose/goose/v3/testservices/neutronmodel"
-	"github.com/go-goose/goose/v3/testservices/neutronservice"
-	"github.com/go-goose/goose/v3/testservices/novaservice"
-	"github.com/go-goose/goose/v3/testservices/swiftservice"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/neutronmodel"
+	"github.com/go-goose/goose/v4/testservices/neutronservice"
+	"github.com/go-goose/goose/v4/testservices/novaservice"
+	"github.com/go-goose/goose/v4/testservices/swiftservice"
 )
 
 const (

--- a/testservices/service.go
+++ b/testservices/service.go
@@ -3,8 +3,8 @@ package testservices
 import (
 	"net/http"
 
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 // An HttpService provides the HTTP API for a service double.

--- a/testservices/swiftservice/service.go
+++ b/testservices/swiftservice/service.go
@@ -10,9 +10,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-goose/goose/v3/swift"
-	"github.com/go-goose/goose/v3/testservices"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/swift"
+	"github.com/go-goose/goose/v4/testservices"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 type object map[string][]byte

--- a/testservices/swiftservice/service_http_test.go
+++ b/testservices/swiftservice/service_http_test.go
@@ -11,9 +11,9 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/swift"
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/identityservice"
+	"github.com/go-goose/goose/v4/swift"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/identityservice"
 )
 
 type SwiftHTTPSuite struct {

--- a/tools/secgroup-delete-all/main.go
+++ b/tools/secgroup-delete-all/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/juju/gnuflag"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/nova"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/nova"
 )
 
 // DeleteAll destroys all security groups except the default

--- a/tools/secgroup-delete-all/main_test.go
+++ b/tools/secgroup-delete-all/main_test.go
@@ -7,12 +7,12 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/go-goose/goose/v3/client"
-	"github.com/go-goose/goose/v3/identity"
-	"github.com/go-goose/goose/v3/nova"
-	"github.com/go-goose/goose/v3/testing/httpsuite"
-	"github.com/go-goose/goose/v3/testservices/hook"
-	"github.com/go-goose/goose/v3/testservices/openstackservice"
+	"github.com/go-goose/goose/v4/client"
+	"github.com/go-goose/goose/v4/identity"
+	"github.com/go-goose/goose/v4/nova"
+	"github.com/go-goose/goose/v4/testing/httpsuite"
+	"github.com/go-goose/goose/v4/testservices/hook"
+	"github.com/go-goose/goose/v4/testservices/openstackservice"
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
Remove the loggo dependency from the non-test code base. You don't need
a loggo dependency directly for logging, instead you just need a Debugf
method. The fact that a direct dependency on this was required makes it
very difficult to iterate the loggo logger in the new modern world of go
mod.

Remove the comment about just depending on loggo, I really think that's
the wrong thing to do.