### PR TITLE
Do not combine unauthorised and forbidden error codes

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,10 +7,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
 
-    - name: Set up Go 1.14
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.14
+        go-version: 1.17
       id: go
 
     - name: Install Dependencies

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -15,6 +15,7 @@ const (
 	DuplicateValueError  = Code("DuplicateValue")
 	TimeoutError         = Code("Timeout")
 	UnauthorisedError    = Code("Unauthorised")
+	ForbiddenError       = Code("Forbidden")
 	NotImplementedError  = Code("NotImplemented")
 	MultipleChoicesError = Code("MultipleChoices")
 )
@@ -97,6 +98,13 @@ func IsUnauthorised(err error) bool {
 	return false
 }
 
+func IsForbidden(err error) bool {
+	if e, ok := err.(*gooseError); ok {
+		return e.causedBy(ForbiddenError)
+	}
+	return false
+}
+
 func IsNotImplemented(err error) bool {
 	if e, ok := err.(*gooseError); ok {
 		return e.causedBy(NotImplementedError)
@@ -155,6 +163,14 @@ func NewUnauthorisedf(cause error, context interface{}, format string, args ...i
 		format = fmt.Sprintf("Unauthorised: %s", context)
 	}
 	return makeErrorf(UnauthorisedError, cause, format, args...)
+}
+
+// NewForbiddenf creates a new Forbidden Error instance with the specified cause.
+func NewForbiddenf(cause error, context interface{}, format string, args ...interface{}) Error {
+	if format == "" {
+		format = fmt.Sprintf("Forbidden: %s", context)
+	}
+	return makeErrorf(ForbiddenError, cause, format, args...)
 }
 
 // NewNotImplementedf creates a new NotImplemented Error instance with the specified cause.

--- a/http/client.go
+++ b/http/client.go
@@ -416,8 +416,10 @@ func handleError(URL string, resp *http.Response) error {
 	switch resp.StatusCode {
 	case http.StatusNotFound:
 		return errors.NewNotFoundf(httpError, "", "Resource at %s not found", URL)
-	case http.StatusForbidden, http.StatusUnauthorized:
+	case http.StatusUnauthorized:
 		return errors.NewUnauthorisedf(httpError, "", "Unauthorised URL %s", URL)
+	case http.StatusForbidden:
+		return errors.NewForbiddenf(httpError, "", string(errBytes))
 	case http.StatusBadRequest:
 		dupExp, _ := regexp.Compile(".*already exists.*")
 		if dupExp.Match(errBytes) {

--- a/testservices/hook/service_gc.go
+++ b/testservices/hook/service_gc.go
@@ -1,4 +1,4 @@
-// +build !gccgo
+//go:build !gccgo
 
 package hook
 

--- a/testservices/hook/service_gccgo.go
+++ b/testservices/hook/service_gccgo.go
@@ -1,4 +1,4 @@
-// +build gccgo
+//go:build gccgo
 
 package hook
 


### PR DESCRIPTION
Both 401 and 403 were being interpreted as an UnauthorisedError. However, 403 can also be used for quota exceeded. The result is that Juju is invalidating credentials when a quota is exceed, instead of simply recording the error and allowing for a retry after the quota issue is fixed.

https://bugs.launchpad.net/juju/+bug/1966375