### PR TITLE
[JUJU-1426] http.StatusConflict, 409, can also be "already exists"

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -420,7 +420,7 @@ func handleError(URL string, resp *http.Response) error {
 		return errors.NewUnauthorisedf(httpError, "", "Unauthorised URL %s", URL)
 	case http.StatusForbidden:
 		return errors.NewForbiddenf(httpError, "", string(errBytes))
-	case http.StatusBadRequest:
+	case http.StatusConflict, http.StatusBadRequest:
 		dupExp, _ := regexp.Compile(".*already exists.*")
 		if dupExp.Match(errBytes) {
 			return errors.NewDuplicateValuef(httpError, "", string(errBytes))


### PR DESCRIPTION
Check http.StatusConflict for already exists as well: 

request (https://x.com:9696/v2.0/security-group-rules) returned unexpected status: 409; error info: {"NeutronError": {"type": "SecurityGroupRuleExists", "message": "Security group rule already exists. Rule id is 602a41b7-c37f-47aa-a001-1eb6d631aa33.", "detail": ""}}

https://bugs.launchpad.net/juju/+bug/1980956