### PR TITLE
[JUJU-3447] Include RemoteGroupID when adding secgroup rules in testservices

### DIFF
--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -331,6 +331,7 @@ func (n *NeutronModel) AddSecurityGroupRule(ruleId string, rule neutron.RuleInfo
 		ParentGroupId:  rule.ParentGroupId,
 		Id:             ruleId,
 		RemoteIPPrefix: rule.RemoteIPPrefix,
+		RemoteGroupID:  rule.RemoteGroupId,
 	}
 	if rule.Direction == "ingress" || rule.Direction == "egress" {
 		newrule.Direction = rule.Direction


### PR DESCRIPTION
Previously this was missing so any added secgoup with RemoteGroupID were instead defaulted to being open to the universe

This was causing false negative test results in juju/juju

### QA Steps
Unsure