### PR TITLE
feat: support to create tags and filter security groups

### DIFF
--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -315,6 +315,11 @@ func (s *LiveTests) TestSecurityGroupsV2WithTagsRollback(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(secGrps, gc.IsNil)
 
+	secGrps, err = s.neutron.SecurityGroupByNameV2("SecurityGroupTest")
+	c.Assert(err, gc.NotNil)
+	c.Assert(err, gc.ErrorMatches, "failed to find security group with name: SecurityGroupTest")
+	c.Assert(secGrps, gc.IsNil)
+
 }
 
 func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -197,7 +197,8 @@ func (s *LiveTests) TestSecurityGroupsV2(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(newSecGrp, gc.Not(gc.IsNil))
 	defer s.deleteSecurityGroup(newSecGrp.Id, c)
-	secGrps, err := s.neutron.ListSecurityGroupsV2()
+	query := neutron.ListSecurityGroupsV2Query{}
+	secGrps, err := s.neutron.ListSecurityGroupsV2(query)
 	c.Assert(err, gc.IsNil)
 	c.Assert(secGrps, gc.Not(gc.HasLen), 0)
 	var found bool
@@ -233,6 +234,35 @@ func (s *LiveTests) TestSecurityGroupsV2(c *gc.C) {
 	}
 	_, err = s.neutron.SecurityGroupByNameV2(newSecGrp.Name)
 	c.Assert(err, gc.Not(gc.IsNil))
+}
+
+func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
+	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing create security group")
+	c.Assert(err, gc.IsNil)
+	c.Assert(newSecGrp, gc.Not(gc.IsNil))
+	defer s.deleteSecurityGroup(newSecGrp.Id, c)
+	err = s.neutron.CreateTags("security-groups", newSecGrp.Id, []string{"awesome-group"})
+	c.Assert(err, gc.IsNil)
+	query := neutron.ListSecurityGroupsV2Query{
+		Tags: []string{"awesome-group"},
+	}
+	secGrps, err := s.neutron.ListSecurityGroupsV2(query)
+	c.Assert(err, gc.IsNil)
+	c.Assert(secGrps, gc.Not(gc.HasLen), 0)
+	var found bool
+	for _, secGrp := range secGrps {
+		c.Check(secGrp.Id, gc.Not(gc.Equals), "")
+		c.Check(secGrp.Name, gc.Not(gc.Equals), "")
+		c.Check(secGrp.Description, gc.Not(gc.Equals), "")
+		c.Check(secGrp.TenantId, gc.Not(gc.Equals), "")
+		// Is this the SecurityGroup we just created?
+		if secGrp.Id == newSecGrp.Id {
+			found = true
+		}
+	}
+	if !found {
+		c.Errorf("expected to find added security group %s", newSecGrp.Name)
+	}
 }
 
 func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -2,6 +2,7 @@ package neutron_test
 
 import (
 	"net"
+	"strings"
 
 	gc "gopkg.in/check.v1"
 
@@ -193,9 +194,10 @@ func (s *LiveTests) deleteSecurityGroup(id string, c *gc.C) {
 }
 
 func (s *LiveTests) TestSecurityGroupsV2(c *gc.C) {
-	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing create security group")
+	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing create security group", []string{})
 	c.Assert(err, gc.IsNil)
 	c.Assert(newSecGrp, gc.Not(gc.IsNil))
+	c.Assert(newSecGrp.Tags, gc.HasLen, 0)
 	defer s.deleteSecurityGroup(newSecGrp.Id, c)
 	query := neutron.ListSecurityGroupsV2Query{}
 	secGrps, err := s.neutron.ListSecurityGroupsV2(query)
@@ -237,12 +239,11 @@ func (s *LiveTests) TestSecurityGroupsV2(c *gc.C) {
 }
 
 func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
-	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing create security group")
+	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing create security group", []string{"awesome-group"})
 	c.Assert(err, gc.IsNil)
 	c.Assert(newSecGrp, gc.Not(gc.IsNil))
+	c.Assert(newSecGrp.Tags, gc.DeepEquals, []string{"awesome-group"})
 	defer s.deleteSecurityGroup(newSecGrp.Id, c)
-	err = s.neutron.ReplaceAllTags("security-groups", newSecGrp.Id, []string{"awesome-group"})
-	c.Assert(err, gc.IsNil)
 
 	// find an existing security group by tag
 	query := neutron.ListSecurityGroupsV2Query{
@@ -250,7 +251,7 @@ func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
 	}
 	secGrps, err := s.neutron.ListSecurityGroupsV2(query)
 	c.Assert(err, gc.IsNil)
-	c.Assert(secGrps, gc.Not(gc.HasLen), 0)
+	c.Assert(secGrps, gc.HasLen, 1)
 	var found bool
 	for _, secGrp := range secGrps {
 		c.Check(secGrp.Id, gc.Not(gc.Equals), "")
@@ -271,11 +272,54 @@ func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(secGrps2, gc.HasLen, 0)
 
+	// create another security group
+	newSecGrp2, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest2", "Testing create security group", []string{"awesome-group", "happy-group"})
+	c.Assert(err, gc.IsNil)
+	c.Assert(newSecGrp2, gc.Not(gc.IsNil))
+	c.Assert(newSecGrp2.Tags, gc.DeepEquals, []string{"awesome-group", "happy-group"})
+	defer s.deleteSecurityGroup(newSecGrp2.Id, c)
+
+	// list with multiple tags
+	query.Tags = []string{"awesome-group", "happy-group"}
+	secGrps3, err := s.neutron.ListSecurityGroupsV2(query)
+	c.Assert(err, gc.IsNil)
+	c.Assert(secGrps3, gc.HasLen, 1)
+
+	for _, secGrp := range secGrps3 {
+		c.Check(secGrp.Id, gc.Not(gc.Equals), "")
+		c.Check(secGrp.Name, gc.Not(gc.Equals), "")
+		c.Check(secGrp.Description, gc.Not(gc.Equals), "")
+		c.Check(secGrp.TenantId, gc.Not(gc.Equals), "")
+	}
+
+	// now we should get two groups back because there are
+	// two groups tagged with "awesome-group"
+	query.Tags = []string{"awesome-group"}
+	secGrps4, err := s.neutron.ListSecurityGroupsV2(query)
+	c.Assert(err, gc.IsNil)
+	c.Assert(secGrps4, gc.HasLen, 2)
+}
+
+func (s *LiveTests) TestSecurityGroupsV2WithTagsRollback(c *gc.C) {
+	// the tag creation fails and is smart enough to roll back (delete the security group)
+	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing create security group", []string{"unit-test-rollback"})
+	c.Assert(err, gc.NotNil)
+	c.Assert(strings.Contains(err.Error(), "creating tags failed, rolled back security group"), gc.Equals, true)
+	c.Assert(newSecGrp, gc.IsNil)
+
+	// try to find the security group, it doesn't exist
+	query := neutron.ListSecurityGroupsV2Query{
+		Tags: []string{"unit-test-rollback"},
+	}
+	secGrps, err := s.neutron.ListSecurityGroupsV2(query)
+	c.Assert(err, gc.IsNil)
+	c.Assert(secGrps, gc.IsNil)
+
 }
 
 func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {
 	// Create and find a SecurityGroup
-	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing find security group by name")
+	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTest", "Testing find security group by name", []string{})
 	c.Assert(err, gc.IsNil)
 	defer s.deleteSecurityGroup(newSecGrp.Id, c)
 	c.Assert(newSecGrp, gc.Not(gc.IsNil))
@@ -290,7 +334,7 @@ func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {
 	c.Assert(err, gc.Not(gc.IsNil))
 	c.Assert(errorSecGrps, gc.HasLen, 0)
 	// Create and find a SecurityGroup with spaces in the name
-	newSecGrp2, err := s.neutron.CreateSecurityGroupV2("Security Group Test", "Testing find security group by name")
+	newSecGrp2, err := s.neutron.CreateSecurityGroupV2("Security Group Test", "Testing find security group by name", []string{})
 	c.Assert(err, gc.IsNil)
 	defer s.deleteSecurityGroup(newSecGrp2.Id, c)
 	c.Assert(newSecGrp2, gc.Not(gc.IsNil))
@@ -302,7 +346,7 @@ func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {
 	}
 	// Create a second SecurityGroup with the same name as one already created,
 	// find both.
-	newSecGrp3, err := s.neutron.CreateSecurityGroupV2(newSecGrp.Name, "Testing find security group by name, 2nd")
+	newSecGrp3, err := s.neutron.CreateSecurityGroupV2(newSecGrp.Name, "Testing find security group by name, 2nd", []string{})
 	c.Assert(err, gc.IsNil)
 	defer s.deleteSecurityGroup(newSecGrp3.Id, c)
 	c.Assert(newSecGrp3, gc.Not(gc.IsNil))
@@ -312,7 +356,7 @@ func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {
 }
 
 func (s *LiveTests) TestSecurityGroupsRulesV2(c *gc.C) {
-	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTestRules", "Testing create security group")
+	newSecGrp, err := s.neutron.CreateSecurityGroupV2("SecurityGroupTestRules", "Testing create security group", []string{})
 	c.Assert(err, gc.IsNil)
 	defer s.deleteSecurityGroup(newSecGrp.Id, c)
 	rule := neutron.RuleInfoV2{

--- a/neutron/live_test.go
+++ b/neutron/live_test.go
@@ -241,8 +241,10 @@ func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(newSecGrp, gc.Not(gc.IsNil))
 	defer s.deleteSecurityGroup(newSecGrp.Id, c)
-	err = s.neutron.CreateTags("security-groups", newSecGrp.Id, []string{"awesome-group"})
+	err = s.neutron.ReplaceAllTags("security-groups", newSecGrp.Id, []string{"awesome-group"})
 	c.Assert(err, gc.IsNil)
+
+	// find an existing security group by tag
 	query := neutron.ListSecurityGroupsV2Query{
 		Tags: []string{"awesome-group"},
 	}
@@ -255,7 +257,6 @@ func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
 		c.Check(secGrp.Name, gc.Not(gc.Equals), "")
 		c.Check(secGrp.Description, gc.Not(gc.Equals), "")
 		c.Check(secGrp.TenantId, gc.Not(gc.Equals), "")
-		// Is this the SecurityGroup we just created?
 		if secGrp.Id == newSecGrp.Id {
 			found = true
 		}
@@ -263,6 +264,13 @@ func (s *LiveTests) TestSecurityGroupsV2WithTags(c *gc.C) {
 	if !found {
 		c.Errorf("expected to find added security group %s", newSecGrp.Name)
 	}
+
+	// security group does not exist with this tag
+	query.Tags = []string{"not-exist-tag"}
+	secGrps2, err := s.neutron.ListSecurityGroupsV2(query)
+	c.Assert(err, gc.IsNil)
+	c.Assert(secGrps2, gc.HasLen, 0)
+
 }
 
 func (s *LiveTests) TestSecurityGroupsByNameV2(c *gc.C) {

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -363,6 +363,7 @@ type SecurityGroupV2 struct {
 	Id          string                `json:"id"`
 	Name        string                `json:"name"`
 	Description string                `json:"description"`
+	Tags        []string              `json:"tags"`
 }
 
 type ListSecurityGroupsV2Query struct {
@@ -376,7 +377,7 @@ func (c *Client) ListSecurityGroupsV2(query ListSecurityGroupsV2Query) ([]Securi
 		Groups []SecurityGroupV2 `json:"security_groups"`
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	endpoint := ApiApplicationPolicyGroupsV2
+	endpoint := ApiSecurityGroupsV2
 
 	if len(query.Tags) > 0 {
 		endpoint = fmt.Sprintf("%s?tags=%s", endpoint, url.QueryEscape(strings.Join(query.Tags, ",")))
@@ -550,16 +551,15 @@ func (c *Client) DeleteSecurityGroupRuleV2(ruleId string) error {
 	return err
 }
 
-// CreateTags creates multiple tags for a resource.
-func (c *Client) CreateTags(resourceType string, resourceId string, tags []string) error {
+// ReplaceAllTags Replaces all tags on the resource.
+func (c *Client) ReplaceAllTags(resourceType string, resourceId string, tags []string) error {
 	var req struct {
 		Tags []string `json:"tags"`
 	}
 	req.Tags = tags
-
 	endpoint := fmt.Sprintf("%s/%s/tags", resourceType, resourceId)
-	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusOK}}
-	err := c.client.SendRequest(client.POST, "tags", "v2.0", endpoint, &requestData)
+	requestData := goosehttp.RequestData{ReqValue: req, ExpectedStatus: []int{http.StatusOK}}
+	err := c.client.SendRequest(client.PUT, "network", "v2.0", endpoint, &requestData)
 	if err != nil {
 		err = errors.Newf(err, "failed to create tags %v for resource type %s", req.Tags, resourceType)
 	}

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -410,8 +410,25 @@ func (c *Client) SecurityGroupByNameV2(name string) ([]SecurityGroupV2, error) {
 	return resp.Groups, nil
 }
 
+func (c *Client) addTagsToSecurityGroup(group *SecurityGroupV2, tags []string) error {
+	if len(tags) > 0 {
+		err := c.ReplaceAllTags("security-groups", group.Id, tags)
+		// we have to roll back, delete the security group
+		if err != nil {
+			if deleteErr := c.DeleteSecurityGroupV2(group.Id); deleteErr != nil {
+				return errors.Newf(deleteErr, "failed to roll back security group with id: %s", group.Id)
+			}
+
+			return errors.Newf(err, "creating tags failed, rolled back security group with id: %s", group.Id)
+		}
+		group.Tags = tags
+	}
+
+	return nil
+}
+
 // CreateSecurityGroupV2 creates a new security group.
-func (c *Client) CreateSecurityGroupV2(name, description string) (*SecurityGroupV2, error) {
+func (c *Client) CreateSecurityGroupV2(name, description string, tags []string) (*SecurityGroupV2, error) {
 	var req struct {
 		SecurityGroupV2 struct {
 			Name        string `json:"name"`
@@ -433,6 +450,12 @@ func (c *Client) CreateSecurityGroupV2(name, description string) (*SecurityGroup
 	if err != nil {
 		return nil, errors.Newf(err, "failed to create a security group with name: %s", name)
 	}
+
+	err = c.addTagsToSecurityGroup(&resp.SecurityGroup, tags)
+	if err != nil {
+		return nil, errors.Newf(err, "failed to create a security group with name: %s", name)
+	}
+
 	return &resp.SecurityGroup, nil
 }
 

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -366,8 +366,9 @@ type SecurityGroupV2 struct {
 	Tags        []string              `json:"tags"`
 }
 
+// ListSecurityGroupsV2Query list security groups that match
+// all entries in Tags (if any are specified) will be returned.
 type ListSecurityGroupsV2Query struct {
-	// List security groups that match all entries in Tags (if any are specified) will be returned.
 	Tags []string
 }
 
@@ -410,23 +411,6 @@ func (c *Client) SecurityGroupByNameV2(name string) ([]SecurityGroupV2, error) {
 	return resp.Groups, nil
 }
 
-func (c *Client) addTagsToSecurityGroup(group *SecurityGroupV2, tags []string) error {
-	if len(tags) > 0 {
-		err := c.ReplaceAllTags("security-groups", group.Id, tags)
-		// we have to roll back, delete the security group
-		if err != nil {
-			if deleteErr := c.DeleteSecurityGroupV2(group.Id); deleteErr != nil {
-				return errors.Newf(deleteErr, "failed to roll back security group with id: %s", group.Id)
-			}
-
-			return errors.Newf(err, "creating tags failed, rolled back security group with id: %s", group.Id)
-		}
-		group.Tags = tags
-	}
-
-	return nil
-}
-
 // CreateSecurityGroupV2 creates a new security group.
 func (c *Client) CreateSecurityGroupV2(name, description string, tags []string) (*SecurityGroupV2, error) {
 	var req struct {
@@ -451,11 +435,23 @@ func (c *Client) CreateSecurityGroupV2(name, description string, tags []string) 
 		return nil, errors.Newf(err, "failed to create a security group with name: %s", name)
 	}
 
-	err = c.addTagsToSecurityGroup(&resp.SecurityGroup, tags)
-	if err != nil {
-		return nil, errors.Newf(err, "failed to create a security group with name: %s", name)
+	// There are no tags to create so we return early.
+	if len(tags) == 0 {
+		return &resp.SecurityGroup, nil
 	}
 
+	// Create the tags for the group.
+	err = c.ReplaceAllTags("security-groups", resp.SecurityGroup.Id, tags)
+	// If this fails, we have to roll back by deleting the security group.
+	if err != nil {
+		if deleteErr := c.DeleteSecurityGroupV2(resp.SecurityGroup.Id); deleteErr != nil {
+			return nil, errors.Newf(deleteErr, "failed to roll back security group with id: %s", resp.SecurityGroup.Id)
+		}
+
+		return nil, errors.Newf(err, "creating tags failed, rolled back security group with id: %s", resp.SecurityGroup.Id)
+	}
+
+	resp.SecurityGroup.Tags = tags
 	return &resp.SecurityGroup, nil
 }
 

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -445,7 +445,7 @@ func (c *Client) CreateSecurityGroupV2(name, description string, tags []string) 
 	// If this fails, we have to roll back by deleting the security group.
 	if err != nil {
 		if deleteErr := c.DeleteSecurityGroupV2(resp.SecurityGroup.Id); deleteErr != nil {
-			return nil, errors.Newf(deleteErr, "failed to roll back security group with id: %s", resp.SecurityGroup.Id)
+			return nil, errors.Newf(deleteErr, "creating tags failed and attempt to roll back the security group was made but failed. security group with id: %s", resp.SecurityGroup.Id)
 		}
 
 		return nil, errors.Newf(err, "creating tags failed, rolled back security group with id: %s", resp.SecurityGroup.Id)

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/go-goose/goose/v5/client"
 	"github.com/go-goose/goose/v5/errors"
@@ -364,13 +365,24 @@ type SecurityGroupV2 struct {
 	Description string                `json:"description"`
 }
 
+type ListSecurityGroupsV2Query struct {
+	// Security groups that match all entries in `Tags` will be returned.
+	Tags []string
+}
+
 // ListSecurityGroupsV2 lists IDs, names, and other details for all security groups.
-func (c *Client) ListSecurityGroupsV2() ([]SecurityGroupV2, error) {
+func (c *Client) ListSecurityGroupsV2(query ListSecurityGroupsV2Query) ([]SecurityGroupV2, error) {
 	var resp struct {
 		Groups []SecurityGroupV2 `json:"security_groups"`
 	}
 	requestData := goosehttp.RequestData{RespValue: &resp}
-	err := c.client.SendRequest(client.GET, "network", "v2.0", ApiSecurityGroupsV2, &requestData)
+	endpoint := ApiApplicationPolicyGroupsV2
+
+	if len(query.Tags) > 0 {
+		endpoint = fmt.Sprintf("%s?tags=%s", endpoint, url.QueryEscape(strings.Join(query.Tags, ",")))
+	}
+
+	err := c.client.SendRequest(client.GET, "network", "v2.0", endpoint, &requestData)
 	if err != nil {
 		return nil, errors.Newf(err, "failed to list security groups")
 	}
@@ -535,5 +547,22 @@ func (c *Client) DeleteSecurityGroupRuleV2(ruleId string) error {
 	if err != nil {
 		err = errors.Newf(err, "failed to delete security group rule with id: %s", ruleId)
 	}
+	return err
+}
+
+// CreateTags creates multiple tags for a resource.
+func (c *Client) CreateTags(resourceType string, resourceId string, tags []string) error {
+	var req struct {
+		Tags []string `json:"tags"`
+	}
+	req.Tags = tags
+
+	endpoint := fmt.Sprintf("%s/%s/tags", resourceType, resourceId)
+	requestData := goosehttp.RequestData{ExpectedStatus: []int{http.StatusOK}}
+	err := c.client.SendRequest(client.POST, "tags", "v2.0", endpoint, &requestData)
+	if err != nil {
+		err = errors.Newf(err, "failed to create tags %v for resource type %s", req.Tags, resourceType)
+	}
+
 	return err
 }

--- a/neutron/neutron.go
+++ b/neutron/neutron.go
@@ -367,7 +367,7 @@ type SecurityGroupV2 struct {
 }
 
 type ListSecurityGroupsV2Query struct {
-	// Security groups that match all entries in `Tags` will be returned.
+	// List security groups that match all entries in Tags (if any are specified) will be returned.
 	Tags []string
 }
 
@@ -574,7 +574,7 @@ func (c *Client) DeleteSecurityGroupRuleV2(ruleId string) error {
 	return err
 }
 
-// ReplaceAllTags Replaces all tags on the resource.
+// ReplaceAllTags replaces all tags on the specified network resource.
 func (c *Client) ReplaceAllTags(resourceType string, resourceId string, tags []string) error {
 	var req struct {
 		Tags []string `json:"tags"`

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -4,7 +4,9 @@
 package neutronmodel
 
 import (
+	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"sync"
 
@@ -176,6 +178,7 @@ func (n *NeutronModel) UpdateSecurityGroup(group neutron.SecurityGroupV2) error 
 	}
 	existingGroup.Name = group.Name
 	existingGroup.Description = group.Description
+	existingGroup.Tags = group.Tags
 	n.groups[group.Id] = *existingGroup
 	return nil
 }
@@ -218,6 +221,15 @@ func (n *NeutronModel) AddSecurityGroup(group neutron.SecurityGroupV2) error {
 	}
 	n.groups[group.Id] = group
 	return nil
+}
+
+func (n *NeutronModel) AddTagsToSecurityGroup(groupId string, tags []string) error {
+	group, _ := n.SecurityGroup(groupId)
+	if group == nil {
+		return testservices.NewNotFoundError(fmt.Sprintf("Resource security_groups %s could not be found.", groupId))
+	}
+	group.Tags = tags
+	return n.UpdateSecurityGroup(*group)
 }
 
 // AddNovaSecurityGroup creates a new security group given a nova.SecurityGroup.
@@ -264,7 +276,35 @@ func (n *NeutronModel) SecurityGroupByName(groupName string) ([]neutron.Security
 		}
 	}
 	return foundGrps, nil
-	//return nil, testservices.NewSecurityGroupByNameNotFoundError(groupName)
+}
+
+func equals(s1 []string, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+
+	for i := 0; i < len(s1); i++ {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (n *NeutronModel) SecurityGroupByTags(tags []string) ([]neutron.SecurityGroupV2, error) {
+	n.rwMu.RLock()
+	defer n.rwMu.RUnlock()
+	var foundGrps []neutron.SecurityGroupV2
+	sort.Strings(tags)
+
+	for _, group := range n.groups {
+		sort.Strings(group.Tags)
+		if equals(group.Tags, tags) {
+			foundGrps = append(foundGrps, group)
+		}
+	}
+	return foundGrps, nil
 }
 
 // NovaSecurityGroupByName retrieves an existing named group, data in

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -282,20 +282,6 @@ func (n *NeutronModel) SecurityGroupByName(groupName string) ([]neutron.Security
 	return foundGrps, nil
 }
 
-func equals(s1 []string, s2 []string) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-
-	for i := 0; i < len(s1); i++ {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 // containsAll check whether all elements in `tags` are present in `groupTags`.
 func containsAll(groupTags, tags []string) bool {
 	tagSet := make(map[string]struct{}, len(groupTags))

--- a/testservices/neutronmodel/neutronmodel.go
+++ b/testservices/neutronmodel/neutronmodel.go
@@ -6,7 +6,6 @@ package neutronmodel
 import (
 	"fmt"
 	"net"
-	"sort"
 	"strconv"
 	"sync"
 
@@ -224,6 +223,11 @@ func (n *NeutronModel) AddSecurityGroup(group neutron.SecurityGroupV2) error {
 }
 
 func (n *NeutronModel) AddTagsToSecurityGroup(groupId string, tags []string) error {
+	// purposely fail to test the rollback
+	if len(tags) > 0 && tags[0] == "unit-test-rollback" {
+		return fmt.Errorf("failed to add tags")
+	}
+
 	group, _ := n.SecurityGroup(groupId)
 	if group == nil {
 		return testservices.NewNotFoundError(fmt.Sprintf("Resource security_groups %s could not be found.", groupId))
@@ -292,15 +296,29 @@ func equals(s1 []string, s2 []string) bool {
 	return true
 }
 
+// containsAll check whether all elements in `tags` are present in `groupTags`.
+func containsAll(groupTags, tags []string) bool {
+	tagSet := make(map[string]struct{}, len(groupTags))
+	for _, tag := range groupTags {
+		tagSet[tag] = struct{}{}
+	}
+
+	for _, tag := range tags {
+		if _, found := tagSet[tag]; !found {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (n *NeutronModel) SecurityGroupByTags(tags []string) ([]neutron.SecurityGroupV2, error) {
 	n.rwMu.RLock()
 	defer n.rwMu.RUnlock()
 	var foundGrps []neutron.SecurityGroupV2
-	sort.Strings(tags)
 
 	for _, group := range n.groups {
-		sort.Strings(group.Tags)
-		if equals(group.Tags, tags) {
+		if containsAll(group.Tags, tags) {
 			foundGrps = append(foundGrps, group)
 		}
 	}

--- a/testservices/neutronservice/service.go
+++ b/testservices/neutronservice/service.go
@@ -187,6 +187,14 @@ func (n *Neutron) addSecurityGroup(group neutron.SecurityGroupV2) error {
 	return n.neutronModel.AddSecurityGroup(group)
 }
 
+// addSecurityGroup creates a new security group.
+func (n *Neutron) addTagsToSecurityGroup(groupId string, tags []string) error {
+	if err := n.ProcessFunctionHook(n, groupId); err != nil {
+		return err
+	}
+	return n.neutronModel.AddTagsToSecurityGroup(groupId, tags)
+}
+
 // securityGroup retrieves an existing group by ID.
 func (n *Neutron) securityGroup(groupId string) (*neutron.SecurityGroupV2, error) {
 	if err := n.ProcessFunctionHook(n, groupId); err != nil {
@@ -201,6 +209,14 @@ func (n *Neutron) securityGroupByName(groupName string) ([]neutron.SecurityGroup
 		return nil, err
 	}
 	return n.neutronModel.SecurityGroupByName(groupName)
+}
+
+// securityGroupByTags retrieves existing tagged group(s).
+func (n *Neutron) securityGroupByTags(tags []string) ([]neutron.SecurityGroupV2, error) {
+	if err := n.ProcessFunctionHook(n, tags); err != nil {
+		return nil, err
+	}
+	return n.neutronModel.SecurityGroupByTags(tags)
 }
 
 // allSecurityGroups returns a list of all existing groups.

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -326,6 +326,18 @@ func (n *Neutron) processGroupId(w http.ResponseWriter, r *http.Request) (*neutr
 
 // handleSecurityGroups handles the /v2.0/security-groups HTTP API.
 func (n *Neutron) handleSecurityGroups(w http.ResponseWriter, r *http.Request) error {
+	// Add tags to security group uses HTTP API "PUT /v2.0/security-groups/{id}/tags".
+	// I know this is ugly, but it's a workaround because the standard Go mux
+	// doesn't support path variables.
+	pattern := `^/v2\.0/security-groups/\d+/tags$`
+	matchedTagsUrl, err := regexp.MatchString(pattern, r.URL.Path)
+	if err != nil {
+		return err
+	}
+	if matchedTagsUrl {
+		return n.handleTags(w, r)
+	}
+
 	switch r.Method {
 	case "GET":
 		group, err := n.processGroupId(w, r)
@@ -333,10 +345,19 @@ func (n *Neutron) handleSecurityGroups(w http.ResponseWriter, r *http.Request) e
 			var groups []neutron.SecurityGroupV2
 			query := r.URL.Query()
 			if len(query) == 1 {
-				secGroupName := query["name"][0]
-				groups, err = n.securityGroupByName(secGroupName)
-				if err != nil {
-					return err
+				if _, ok := query["name"]; ok {
+					secGroupName := query["name"][0]
+					groups, err = n.securityGroupByName(secGroupName)
+					if err != nil {
+						return err
+					}
+				} else if _, ok = query["tags"]; ok {
+					tagsStr := query["tags"][0]
+					tags := strings.Split(tagsStr, ",")
+					groups, err = n.securityGroupByTags(tags)
+					if err != nil {
+						return err
+					}
 				}
 			} else {
 				groups = n.allSecurityGroups()
@@ -445,6 +466,48 @@ func (n *Neutron) handleSecurityGroups(w http.ResponseWriter, r *http.Request) e
 			return err
 		}
 	}
+	return fmt.Errorf("unknown request method %q for %s", r.Method, r.URL.Path)
+}
+
+// handleTags handles the /v2.0/{resourceType}/{resourceId}/tags HTTP API.
+func (n *Neutron) handleTags(w http.ResponseWriter, r *http.Request) error {
+	switch r.Method {
+	case "PUT":
+		path, ok := strings.CutPrefix(r.URL.Path, "/v2.0/security-groups/")
+		if !ok {
+			return fmt.Errorf("could not cut path prefix for handle tags")
+		}
+
+		groupId, ok := strings.CutSuffix(path, "/tags")
+		if !ok {
+			log.Println("something wrong 2")
+			return fmt.Errorf("could not cut suffix for handle tags")
+		}
+
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil || len(body) == 0 {
+			return errBadRequestIncorrect
+		}
+
+		var req struct {
+			Tags []string `json:"tags"`
+		}
+		if err = json.Unmarshal(body, &req); err != nil {
+			return err
+		}
+
+		if err := n.addTagsToSecurityGroup(groupId, req.Tags); err != nil {
+			return err
+		}
+
+		var resp struct {
+			Tags []string `json:"tags"`
+		}
+
+		resp.Tags = req.Tags
+		return sendJSON(http.StatusOK, resp, w, r)
+	}
+
 	return fmt.Errorf("unknown request method %q for %s", r.Method, r.URL.Path)
 }
 

--- a/testservices/neutronservice/service_http.go
+++ b/testservices/neutronservice/service_http.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -473,15 +474,14 @@ func (n *Neutron) handleSecurityGroups(w http.ResponseWriter, r *http.Request) e
 func (n *Neutron) handleTags(w http.ResponseWriter, r *http.Request) error {
 	switch r.Method {
 	case "PUT":
-		path, ok := strings.CutPrefix(r.URL.Path, "/v2.0/security-groups/")
-		if !ok {
-			return fmt.Errorf("could not cut path prefix for handle tags")
-		}
-
-		groupId, ok := strings.CutSuffix(path, "/tags")
-		if !ok {
-			log.Println("something wrong 2")
-			return fmt.Errorf("could not cut suffix for handle tags")
+		pattern := `^/v2\.0/security-groups/(\d+)/tags$`
+		re := regexp.MustCompile(pattern)
+		matches := re.FindStringSubmatch(r.URL.Path)
+		var groupId string
+		if len(matches) > 1 {
+			groupId = matches[1]
+		} else {
+			return fmt.Errorf("could get group id handle tags")
 		}
 
 		body, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
This PR adds a new API to:
#### 1. Add tags to a resource -- in this case it's a security group.
This is done through the `PUT /v2.0/{resourceType}/{resourceId}/tags` endpoint where `resourceType` and `resourceId` are `security-groups` and the identifier, respectively. This endpoint replaces a group's existing tags with the given tags in the request body.

Quoting from Openstack docs ([ref](https://docs.openstack.org/api-ref/network/v2/#standard-attributes-tag-extension)), `resourceType` may be:

> This includes networks, ports, subnets, subnet pools, floating IPs, routers, security groups, security group rules, QoS policies and trunks.


One thing I have noticed is that Openstack documentation mentions that a `POST` method exists to create tags for a resource but upon testing, I get error:
```json
{
	"NeutronError": {
		"type": "HTTPNotFound",
		"message": "not supported",
		"detail": ""
	}
}
```

I then tested using Openstack CLI to create a security group with tags, and they use the `PUT` method as opposed of `POST`. For consistency, I have moved forward to using the `PUT` method.

```bash
openstack security group create <group-name> --tag <tag-name> --debug
```


#### 2. Fetch security groups by tags

This is done through the `GET /v2.0/security-groups` by passing a `tags` query parameter. Multiple tags should be separated by a comma.

Card: https://warthogs.atlassian.net/browse/JUJU-8225