### PR TITLE
feat: expose `extra_specs` field in flavor detail

### DIFF
--- a/nova/nova.go
+++ b/nova/nova.go
@@ -141,12 +141,13 @@ func (c *Client) ListFlavors() ([]Entity, error) {
 
 // FlavorDetail describes detailed information about a flavor.
 type FlavorDetail struct {
-	Name  string
-	RAM   int    // Available RAM, in MB
-	VCPUs int    // Number of virtual CPU (cores)
-	Disk  int    // Available root partition space, in GB
-	Id    string `json:"-"`
-	Links []Link
+	Name       string
+	RAM        int    // Available RAM, in MB
+	VCPUs      int    // Number of virtual CPU (cores)
+	Disk       int    // Available root partition space, in GB
+	Id         string `json:"-"`
+	Links      []Link
+	ExtraSpecs map[string]interface{} `json:"extra_specs"`
 }
 
 // Allow FlavorDetail slices to be sorted by named attribute.


### PR DESCRIPTION
As part of this task, we need a way to identify whether or not a flavor supports `SEV` (Secure Encrypted Virtualization). This can be done by looking up the `extra_specs` field in the response of `GET /flavors/detail` endpoint. This PR adds `extra_specs` in `FlavorDetail` struct. 

An `SEV` flavor will have ` hw:mem_encryption="true"`.

Card: https://warthogs.atlassian.net/browse/JUJU-8161