### PR TITLE
fix: trust auth JSON tags

### DIFF
--- a/identity/v3userpass.go
+++ b/identity/v3userpass.go
@@ -58,7 +58,7 @@ type v3AuthToken struct {
 type v3AuthScope struct {
 	Domain  *v3AuthDomain  `json:"domain,omitempty"`
 	Project *v3AuthProject `json:"project,omitempty"`
-	Trust   *v3AuthTrust   `json:"trust,omitempty"`
+	Trust   *v3AuthTrust   `json:"OS-TRUST:trust,omitempty"`
 }
 
 // v3AuthProject contains the project scope for the authentication

--- a/testservices/identityservice/v3userpass.go
+++ b/testservices/identityservice/v3userpass.go
@@ -38,7 +38,7 @@ type V3UserPassRequest struct {
 			} `json:"domain"`
 			Trust struct {
 				ID string `json:"id"`
-			} `json:"trust"`
+			} `json:"OS-TRUST:trust"`
 		} `json:"scope"`
 	} `json:"auth"`
 }


### PR DESCRIPTION
Support for Keystone trusts was added under https://github.com/go-goose/goose/pull/105.

The original change was correct, but the struct tags were changed before landing. As it turns out, the specific form is required by O7k, so we restore it here.