### PR TITLE
feat: add cinder DeleteAttachment for stale volume attachments

### DIFF
--- a/cinder/autogenerated_client.go
+++ b/cinder/autogenerated_client.go
@@ -405,10 +405,14 @@ type GetVolumesDetailParams struct {
 }
 
 type VolumeAttachment struct {
-	Device   string `json:"device"`
-	Id       string `json:"id"`
-	ServerId string `json:"server_id"`
-	VolumeId string `json:"volume_id"`
+	Device string `json:"device"`
+	Id     string `json:"id"`
+	// AttachmentId is the id of the attachment itself. On modern clouds Id is
+	// the volume id, so callers targeting a specific attachment (e.g. for
+	// os-force_detach) must use this field.
+	AttachmentId string `json:"attachment_id"`
+	ServerId     string `json:"server_id"`
+	VolumeId     string `json:"volume_id"`
 }
 
 type Volume struct {
@@ -1698,4 +1702,25 @@ func listAvailabilityZones(client *Client) (*GetAvailabilityZonesResults, error)
 	json.Unmarshal(body, &results)
 
 	return &results, nil
+}
+
+// DeleteAttachmentParams holds the parameters for deleting a volume attachment.
+type DeleteAttachmentParams struct {
+	TenantId     string `json:"-"`
+	AttachmentId string `json:"-"`
+}
+
+// attachmentsMicroversion is the block-storage microversion at which the
+// attachments API (used by deleteAttachment) became available.
+const attachmentsMicroversion = "volume 3.27"
+
+// Deletes a volume attachment via the block-storage attachments API.
+func deleteAttachment(c *Client, args DeleteAttachmentParams) error {
+	requestData := goosehttp.RequestData{
+		ReqHeaders:     http.Header{"OpenStack-API-Version": []string{attachmentsMicroversion}},
+		ExpectedStatus: []int{http.StatusOK, http.StatusAccepted, http.StatusNoContent},
+	}
+	urlPath := url.URL{Path: fmt.Sprintf("attachments/%s", args.AttachmentId)}
+	url := c.endpoint.ResolveReference(&urlPath).String()
+	return c.client.JsonRequest(client.DELETE, url, "", &requestData, nil)
 }

--- a/cinder/client.go
+++ b/cinder/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-goose/goose/v5/errors"
@@ -359,6 +360,27 @@ func (c *Client) ListVolumeAvailabilityZones() ([]AvailabilityZone, error) {
 // frees the volume. Unlike the os-force_detach admin action this is permitted
 // for the volume's owner.
 func (c *Client) DeleteAttachment(attachmentId string) error {
-	return deleteAttachment(c, DeleteAttachmentParams{
+	if isCinderV2Endpoint(c.endpoint) {
+		return errors.NewNotImplementedf(
+			nil, nil, "volume attachments require Block Storage API v3.27",
+		)
+	}
+
+	err := deleteAttachment(c, DeleteAttachmentParams{
 		TenantId: c.tenantId, AttachmentId: attachmentId})
+	if httpErr, ok := err.(*goosehttp.HttpError); ok && httpErr.StatusCode == http.StatusNotAcceptable {
+		return errors.NewNotImplementedf(
+			err, nil, "the server does not support Block Storage API v3.27",
+		)
+	}
+	return err
+}
+
+func isCinderV2Endpoint(endpoint *url.URL) bool {
+	for _, part := range strings.Split(endpoint.Path, "/") {
+		if part == "v2" || part == "v2.0" {
+			return true
+		}
+	}
+	return false
 }

--- a/cinder/client.go
+++ b/cinder/client.go
@@ -351,3 +351,14 @@ func (c *Client) ListVolumeAvailabilityZones() ([]AvailabilityZone, error) {
 	}
 	return resp.AvailabilityZoneInfo, nil
 }
+
+// DeleteAttachment removes a volume attachment through the block-storage
+// attachments API. Cinder checks with the Compute API first: while the
+// attachment's instance is still using the volume it refuses with 409
+// (Conflict), and once the instance is gone it deletes the attachment and
+// frees the volume. Unlike the os-force_detach admin action this is permitted
+// for the volume's owner.
+func (c *Client) DeleteAttachment(attachmentId string) error {
+	return deleteAttachment(c, DeleteAttachmentParams{
+		TenantId: c.tenantId, AttachmentId: attachmentId})
+}

--- a/cinder/client_test.go
+++ b/cinder/client_test.go
@@ -40,15 +40,18 @@ func (s *CinderTestSuite) SetUpSuite(c *gc.C) {
 		return
 	}
 
-	endpoint, err := url.Parse("http://volume.testing/v2/" + testId)
+	s.client = s.newClient(c, "v2")
+}
+
+func (s *CinderTestSuite) newClient(c *gc.C, version string) *Client {
+	endpoint, err := url.Parse(fmt.Sprintf("http://volume.testing/%s/%s", version, testId))
 	c.Assert(err, gc.IsNil)
 
-	cinderClient := NewClient(
+	return NewClient(
 		testId,
 		endpoint,
 		SetAuthHeaderFn(func() string { return testToken }, s.localDo),
 	)
-	s.client = cinderClient
 }
 
 func (s *CinderTestSuite) SetUpTest(c *gc.C) {
@@ -455,9 +458,10 @@ func (s *CinderTestSuite) TestDeleteVolume(c *gc.C) {
 func (s *CinderTestSuite) TestDeleteAttachment(c *gc.C) {
 
 	const attachmentId = "test-attachment"
+	client := s.newClient(c, "v3")
 
 	numCalls := 0
-	s.HandleFunc("/v2/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
+	s.HandleFunc("/v3/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		c.Check(req.Method, gc.Equals, "DELETE")
@@ -468,7 +472,7 @@ func (s *CinderTestSuite) TestDeleteAttachment(c *gc.C) {
 		w.(*responseWriter).Body = ioutil.NopCloser(bytes.NewBuffer([]byte{}))
 	})
 
-	err := s.client.DeleteAttachment(attachmentId)
+	err := client.DeleteAttachment(attachmentId)
 	c.Assert(numCalls, gc.Equals, 1)
 	c.Assert(err, gc.IsNil)
 }
@@ -476,9 +480,10 @@ func (s *CinderTestSuite) TestDeleteAttachment(c *gc.C) {
 func (s *CinderTestSuite) TestDeleteAttachmentConflict(c *gc.C) {
 
 	const attachmentId = "test-attachment"
+	client := s.newClient(c, "v3")
 
 	numCalls := 0
-	s.HandleFunc("/v2/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
+	s.HandleFunc("/v3/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
 		numCalls++
 
 		c.Check(req.Method, gc.Equals, "DELETE")
@@ -488,10 +493,30 @@ func (s *CinderTestSuite) TestDeleteAttachmentConflict(c *gc.C) {
 			"Volume status must be available or error or detaching to detach."))
 	})
 
-	err := s.client.DeleteAttachment(attachmentId)
+	err := client.DeleteAttachment(attachmentId)
 	c.Assert(numCalls, gc.Equals, 1)
 	c.Assert(err, gc.NotNil)
 	c.Assert(gooseerrors.IsConflict(err), gc.Equals, true)
+}
+
+func (s *CinderTestSuite) TestDeleteAttachmentUnsupportedV2(c *gc.C) {
+	err := s.client.DeleteAttachment("test-attachment")
+	c.Assert(err, gc.NotNil)
+	c.Assert(gooseerrors.IsNotImplemented(err), gc.Equals, true)
+}
+
+func (s *CinderTestSuite) TestDeleteAttachmentUnsupportedMicroversion(c *gc.C) {
+	const attachmentId = "test-attachment"
+	client := s.newClient(c, "v3")
+
+	s.HandleFunc("/v3/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
+		w.(*responseWriter).Response.StatusCode = http.StatusNotAcceptable
+		w.(*responseWriter).Body = ioutil.NopCloser(bytes.NewBufferString("unsupported microversion"))
+	})
+
+	err := client.DeleteAttachment(attachmentId)
+	c.Assert(err, gc.NotNil)
+	c.Assert(gooseerrors.IsNotImplemented(err), gc.Equals, true)
 }
 
 func (s *CinderTestSuite) TestUpdateVolume(c *gc.C) {

--- a/cinder/client_test.go
+++ b/cinder/client_test.go
@@ -12,6 +12,8 @@ import (
 	"net/url"
 
 	gc "gopkg.in/check.v1"
+
+	gooseerrors "github.com/go-goose/goose/v5/errors"
 )
 
 const (
@@ -448,6 +450,48 @@ func (s *CinderTestSuite) TestDeleteVolume(c *gc.C) {
 	err := s.client.DeleteVolume(testId)
 	c.Assert(numCalls, gc.Equals, 1)
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *CinderTestSuite) TestDeleteAttachment(c *gc.C) {
+
+	const attachmentId = "test-attachment"
+
+	numCalls := 0
+	s.HandleFunc("/v2/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
+		numCalls++
+
+		c.Check(req.Method, gc.Equals, "DELETE")
+		c.Check(req.Header["X-Auth-Token"], gc.DeepEquals, []string{testToken})
+		c.Check(req.Header["Openstack-Api-Version"], gc.DeepEquals, []string{"volume 3.27"})
+
+		w.(*responseWriter).Response.StatusCode = 200
+		w.(*responseWriter).Body = ioutil.NopCloser(bytes.NewBuffer([]byte{}))
+	})
+
+	err := s.client.DeleteAttachment(attachmentId)
+	c.Assert(numCalls, gc.Equals, 1)
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *CinderTestSuite) TestDeleteAttachmentConflict(c *gc.C) {
+
+	const attachmentId = "test-attachment"
+
+	numCalls := 0
+	s.HandleFunc("/v2/"+testId+"/attachments/"+attachmentId, func(w http.ResponseWriter, req *http.Request) {
+		numCalls++
+
+		c.Check(req.Method, gc.Equals, "DELETE")
+
+		w.(*responseWriter).Response.StatusCode = http.StatusConflict
+		w.(*responseWriter).Body = ioutil.NopCloser(bytes.NewBufferString(
+			"Volume status must be available or error or detaching to detach."))
+	})
+
+	err := s.client.DeleteAttachment(attachmentId)
+	c.Assert(numCalls, gc.Equals, 1)
+	c.Assert(err, gc.NotNil)
+	c.Assert(gooseerrors.IsConflict(err), gc.Equals, true)
 }
 
 func (s *CinderTestSuite) TestUpdateVolume(c *gc.C) {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,6 +18,7 @@ const (
 	ForbiddenError       = Code("Forbidden")
 	NotImplementedError  = Code("NotImplemented")
 	MultipleChoicesError = Code("MultipleChoices")
+	ConflictError        = Code("Conflict")
 )
 
 // Error instances store an optional error cause.
@@ -119,6 +120,13 @@ func IsMultipleChoices(err error) bool {
 	return false
 }
 
+func IsConflict(err error) bool {
+	if e, ok := err.(*gooseError); ok {
+		return e.causedBy(ConflictError)
+	}
+	return false
+}
+
 // makeErrorf creates a new Error instance with the specified cause.
 func makeErrorf(code Code, cause error, format string, args ...interface{}) Error {
 	return &gooseError{
@@ -186,4 +194,12 @@ func NewMultipleChoicesf(cause error, context interface{}, format string, args .
 		format = fmt.Sprintf("Not implemented: %s", context)
 	}
 	return makeErrorf(MultipleChoicesError, cause, format, args...)
+}
+
+// NewConflictf creates a new Conflict Error instance with the specified cause.
+func NewConflictf(cause error, context interface{}, format string, args ...interface{}) Error {
+	if format == "" {
+		format = fmt.Sprintf("Conflict: %s", context)
+	}
+	return makeErrorf(ConflictError, cause, format, args...)
 }

--- a/http/client.go
+++ b/http/client.go
@@ -423,6 +423,9 @@ func handleError(URL string, resp *http.Response) error {
 		if dupExp.Match(errBytes) {
 			return errors.NewDuplicateValuef(httpError, "", string(errBytes))
 		}
+		if resp.StatusCode == http.StatusConflict {
+			return errors.NewConflictf(httpError, "", string(errBytes))
+		}
 	case http.StatusMultipleChoices:
 		return errors.NewMultipleChoicesf(httpError, "", "")
 	}

--- a/http/client.go
+++ b/http/client.go
@@ -417,14 +417,14 @@ func handleError(URL string, resp *http.Response) error {
 	case http.StatusUnauthorized:
 		return errors.NewUnauthorisedf(httpError, "", "Unauthorised URL %s", URL)
 	case http.StatusForbidden:
-		return errors.NewForbiddenf(httpError, "", string(errBytes))
+		return errors.NewForbiddenf(httpError, "", "%s", errInfo)
 	case http.StatusConflict, http.StatusBadRequest:
 		dupExp, _ := regexp.Compile(".*already exists.*")
 		if dupExp.Match(errBytes) {
-			return errors.NewDuplicateValuef(httpError, "", string(errBytes))
+			return errors.NewDuplicateValuef(httpError, "", "%s", errInfo)
 		}
 		if resp.StatusCode == http.StatusConflict {
-			return errors.NewConflictf(httpError, "", string(errBytes))
+			return errors.NewConflictf(httpError, "", "%s", errInfo)
 		}
 	case http.StatusMultipleChoices:
 		return errors.NewMultipleChoicesf(httpError, "", "")

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -207,6 +207,11 @@ func (s *HTTPClientTestSuite) TestHandleForbiddenError(c *gc.C) {
 	c.Assert(errors.IsForbidden(err), gc.Equals, true)
 }
 
+func (s *HTTPClientTestSuite) TestHandleConflictError(c *gc.C) {
+	err := s.setupErrorRequest(c, http.StatusConflict)
+	c.Assert(errors.IsConflict(err), gc.Equals, true)
+}
+
 func (s *HTTPClientTestSuite) testRetryAfter(c *gc.C,
 	retryAfter func(*time.Time, http.ResponseWriter),
 	verifyWait func(time.Time) (time.Duration, bool)) {

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -431,6 +431,43 @@ func (s *HTTPSClientTestSuite) TestBrokenBodyJSONUnmarshalling(c *gc.C) {
 	c.Check(err, gc.ErrorMatches, `Unparsable json error body: \"{\\\"itemNotFound\\\": {}}\"`)
 }
 
+func (s *HTTPSClientTestSuite) TestHandleErrorTreatsResponseMessageAsData(c *gc.C) {
+	tests := []struct {
+		status int
+		body   string
+	}{
+		{http.StatusForbidden, "quota is 100% exhausted"},
+		{http.StatusBadRequest, "resource 100% already exists"},
+		{http.StatusConflict, "volume is 100% attached"},
+	}
+
+	for _, test := range tests {
+		resp := &http.Response{
+			StatusCode: test.status,
+			Header:     http.Header{},
+			Body:       ioutil.NopCloser(strings.NewReader(test.body)),
+		}
+		err := handleError("http://testing.invalid", resp)
+		c.Assert(err, gc.NotNil)
+		message := strings.SplitN(err.Error(), "\n", 2)[0]
+		c.Check(message, gc.Equals, test.body, gc.Commentf("status %d", test.status))
+	}
+}
+
+func (s *HTTPSClientTestSuite) TestHandleErrorUsesDecodedJSONMessage(c *gc.C) {
+	body := `{"forbidden": {"message": "quota is 100% exhausted", "code": 403}}`
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{"Content-Type": []string{contentTypeJSON}},
+		Body:       ioutil.NopCloser(strings.NewReader(body)),
+	}
+
+	err := handleError("http://testing.invalid", resp)
+	c.Assert(err, gc.NotNil)
+	message := strings.SplitN(err.Error(), "\n", 2)[0]
+	c.Check(message, gc.Equals, "Failed: 403 forbidden: quota is 100% exhausted")
+}
+
 type nopReadCloser struct{}
 
 func (nopReadCloser) Read([]byte) (int, error) {


### PR DESCRIPTION
Adds `DeleteAttachment` to remove a Cinder volume attachment via the attachments API (microversion 3.27), to free a volume left wedged in `detaching` after its instance was deleted mid-detach.
Cinder refuses with 409 while the instance still uses the volume, so non-duplicate 409s now map to a new `Conflict` error (`errors.IsConflict`) — split into its own commit since it affects all goose APIs via `handleError`.

`go test ./...` passes; new tests cover the 409 mapping and the cinder path.