### PR TITLE
Preserve default transport settings for non-validating clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -130,17 +130,24 @@ func WithInsecureHTTPClient(client *http.Client) Option {
 	}
 }
 
+func newInsecureHTTPClient() *http.Client {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if ok {
+		transport = transport.Clone()
+	} else {
+		transport = &http.Transport{}
+	}
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = true
+	return &http.Client{Transport: transport}
+}
+
 func newOptions() *options {
 	return &options{
 		httpHeadersFunc: goosehttp.DefaultHeaders,
 		httpClient:      &http.Client{},
-		insecureHTTPClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			},
-		},
 	}
 }
 
@@ -219,6 +226,9 @@ func NewNonValidatingPublicClient(baseURL string, logger logging.CompatLogger, o
 	for _, option := range options {
 		option(opts)
 	}
+	if opts.insecureHTTPClient == nil {
+		opts.insecureHTTPClient = newInsecureHTTPClient()
+	}
 
 	return &client{
 		baseURL: baseURL,
@@ -249,6 +259,9 @@ func NewNonValidatingClient(creds *identity.Credentials, authMethod identity.Aut
 	opts := newOptions()
 	for _, option := range options {
 		option(opts)
+	}
+	if opts.insecureHTTPClient == nil {
+		opts.insecureHTTPClient = newInsecureHTTPClient()
 	}
 
 	return newClient(creds, authMethod, goosehttp.New(

--- a/client/client.go
+++ b/client/client.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"sort"
@@ -136,19 +135,7 @@ func newInsecureHTTPClient() *http.Client {
 	if ok {
 		transport = transport.Clone()
 	} else {
-		// Match the explicit defaults used by net/http.DefaultTransport.
-		transport = &http.Transport{
-			Proxy: http.ProxyFromEnvironment,
-			DialContext: (&net.Dialer{
-				Timeout:   30 * time.Second,
-				KeepAlive: 30 * time.Second,
-			}).DialContext,
-			ForceAttemptHTTP2:     true,
-			MaxIdleConns:          100,
-			IdleConnTimeout:       90 * time.Second,
-			TLSHandshakeTimeout:   10 * time.Second,
-			ExpectContinueTimeout: 1 * time.Second,
-		}
+		transport = &http.Transport{}
 	}
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}
@@ -159,8 +146,9 @@ func newInsecureHTTPClient() *http.Client {
 
 func newOptions() *options {
 	return &options{
-		httpHeadersFunc: goosehttp.DefaultHeaders,
-		httpClient:      &http.Client{},
+		httpHeadersFunc:    goosehttp.DefaultHeaders,
+		httpClient:         &http.Client{},
+		insecureHTTPClient: newInsecureHTTPClient(),
 	}
 }
 
@@ -239,9 +227,6 @@ func NewNonValidatingPublicClient(baseURL string, logger logging.CompatLogger, o
 	for _, option := range options {
 		option(opts)
 	}
-	if opts.insecureHTTPClient == nil {
-		opts.insecureHTTPClient = newInsecureHTTPClient()
-	}
 
 	return &client{
 		baseURL: baseURL,
@@ -272,9 +257,6 @@ func NewNonValidatingClient(creds *identity.Credentials, authMethod identity.Aut
 	opts := newOptions()
 	for _, option := range options {
 		option(opts)
-	}
-	if opts.insecureHTTPClient == nil {
-		opts.insecureHTTPClient = newInsecureHTTPClient()
 	}
 
 	return newClient(creds, authMethod, goosehttp.New(

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"sort"
@@ -135,7 +136,19 @@ func newInsecureHTTPClient() *http.Client {
 	if ok {
 		transport = transport.Clone()
 	} else {
-		transport = &http.Transport{}
+		// Match the explicit defaults used by net/http.DefaultTransport.
+		transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
 	}
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}

--- a/client/client.go
+++ b/client/client.go
@@ -130,25 +130,29 @@ func WithInsecureHTTPClient(client *http.Client) Option {
 	}
 }
 
-func newInsecureHTTPClient() *http.Client {
+func newHTTPClient(skipVerify bool) *http.Client {
 	transport, ok := http.DefaultTransport.(*http.Transport)
 	if ok {
 		transport = transport.Clone()
-	} else {
+	} else if skipVerify {
 		transport = &http.Transport{}
+	} else {
+		return &http.Client{Transport: http.DefaultTransport}
 	}
-	if transport.TLSClientConfig == nil {
-		transport.TLSClientConfig = &tls.Config{}
+	if skipVerify {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
 	}
-	transport.TLSClientConfig.InsecureSkipVerify = true
 	return &http.Client{Transport: transport}
 }
 
 func newOptions() *options {
 	return &options{
 		httpHeadersFunc:    goosehttp.DefaultHeaders,
-		httpClient:         &http.Client{},
-		insecureHTTPClient: newInsecureHTTPClient(),
+		httpClient:         newHTTPClient(false),
+		insecureHTTPClient: newHTTPClient(true),
 	}
 }
 

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 )
 
 type fakeRoundTripper struct {
@@ -15,6 +16,20 @@ func TestCustomDefaultTransport(t *testing.T) {
 	original := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = original })
 	http.DefaultTransport = &fakeRoundTripper{}
+
+	transport := newInsecureHTTPClient().Transport.(*http.Transport)
+	if transport.Proxy == nil ||
+		transport.DialContext == nil ||
+		!transport.ForceAttemptHTTP2 ||
+		transport.MaxIdleConns != 100 ||
+		transport.IdleConnTimeout != 90*time.Second ||
+		transport.TLSHandshakeTimeout != 10*time.Second ||
+		transport.ExpectContinueTimeout != time.Second {
+		t.Fatalf("unexpected fallback transport settings: %#v", transport)
+	}
+	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("fallback transport does not disable certificate verification")
+	}
 
 	NewPublicClient("https://example.invalid", nil)
 	NewNonValidatingPublicClient("https://example.invalid", nil)

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -1,0 +1,60 @@
+package client
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type fakeRoundTripper struct {
+	http.RoundTripper
+}
+
+func TestCustomDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+	http.DefaultTransport = &fakeRoundTripper{}
+
+	NewPublicClient("https://example.invalid", nil)
+	NewNonValidatingPublicClient("https://example.invalid", nil)
+	NewNonValidatingPublicClient("https://example.invalid", nil, WithInsecureHTTPClient(&http.Client{}))
+}
+
+func TestNewInsecureHTTPClientPreservesDefaultTransport(t *testing.T) {
+	original := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	proxyURL, err := url.Parse("http://proxy.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultTransport := &http.Transport{
+		Proxy:           http.ProxyURL(proxyURL),
+		MaxIdleConns:    42,
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+	}
+	http.DefaultTransport = defaultTransport
+
+	transport := newInsecureHTTPClient().Transport.(*http.Transport)
+	if transport.Proxy == nil {
+		t.Fatal("default proxy setting was not preserved")
+	}
+	request, err := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotProxyURL, err := transport.Proxy(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotProxyURL.String() != proxyURL.String() || transport.MaxIdleConns != 42 {
+		t.Fatalf("default transport settings were not preserved: %#v", transport)
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify || transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected TLS configuration: %#v", transport.TLSClientConfig)
+	}
+	if defaultTransport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("default transport was modified")
+	}
+}

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 )
 
 type fakeRoundTripper struct {
@@ -16,20 +15,6 @@ func TestCustomDefaultTransport(t *testing.T) {
 	original := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = original })
 	http.DefaultTransport = &fakeRoundTripper{}
-
-	transport := newInsecureHTTPClient().Transport.(*http.Transport)
-	if transport.Proxy == nil ||
-		transport.DialContext == nil ||
-		!transport.ForceAttemptHTTP2 ||
-		transport.MaxIdleConns != 100 ||
-		transport.IdleConnTimeout != 90*time.Second ||
-		transport.TLSHandshakeTimeout != 10*time.Second ||
-		transport.ExpectContinueTimeout != time.Second {
-		t.Fatalf("unexpected fallback transport settings: %#v", transport)
-	}
-	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
-		t.Fatal("fallback transport does not disable certificate verification")
-	}
 
 	NewPublicClient("https://example.invalid", nil)
 	NewNonValidatingPublicClient("https://example.invalid", nil)

--- a/client/options_test.go
+++ b/client/options_test.go
@@ -14,14 +14,24 @@ type fakeRoundTripper struct {
 func TestCustomDefaultTransport(t *testing.T) {
 	original := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = original })
-	http.DefaultTransport = &fakeRoundTripper{}
+	defaultTransport := &fakeRoundTripper{}
+	http.DefaultTransport = defaultTransport
+
+	options := newOptions()
+	if options.httpClient.Transport != defaultTransport {
+		t.Fatal("custom default transport was not preserved")
+	}
+	insecureTransport, ok := options.insecureHTTPClient.Transport.(*http.Transport)
+	if !ok || insecureTransport.TLSClientConfig == nil || !insecureTransport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatalf("unexpected insecure transport: %#v", options.insecureHTTPClient.Transport)
+	}
 
 	NewPublicClient("https://example.invalid", nil)
 	NewNonValidatingPublicClient("https://example.invalid", nil)
 	NewNonValidatingPublicClient("https://example.invalid", nil, WithInsecureHTTPClient(&http.Client{}))
 }
 
-func TestNewInsecureHTTPClientPreservesDefaultTransport(t *testing.T) {
+func TestNewHTTPClientsPreserveDefaultTransport(t *testing.T) {
 	original := http.DefaultTransport
 	t.Cleanup(func() { http.DefaultTransport = original })
 
@@ -36,23 +46,41 @@ func TestNewInsecureHTTPClientPreservesDefaultTransport(t *testing.T) {
 	}
 	http.DefaultTransport = defaultTransport
 
-	transport := newInsecureHTTPClient().Transport.(*http.Transport)
-	if transport.Proxy == nil {
-		t.Fatal("default proxy setting was not preserved")
-	}
 	request, err := http.NewRequest(http.MethodGet, "https://example.invalid", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gotProxyURL, err := transport.Proxy(request)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if gotProxyURL.String() != proxyURL.String() || transport.MaxIdleConns != 42 {
-		t.Fatalf("default transport settings were not preserved: %#v", transport)
-	}
-	if !transport.TLSClientConfig.InsecureSkipVerify || transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
-		t.Fatalf("unexpected TLS configuration: %#v", transport.TLSClientConfig)
+	options := newOptions()
+	for _, test := range []struct {
+		name       string
+		client     *http.Client
+		skipVerify bool
+	}{
+		{name: "validating", client: options.httpClient},
+		{name: "non-validating", client: options.insecureHTTPClient, skipVerify: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			transport, ok := test.client.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("unexpected transport: %#v", test.client.Transport)
+			}
+			if transport == defaultTransport {
+				t.Fatal("default transport was not cloned")
+			}
+			if transport.Proxy == nil {
+				t.Fatal("default proxy setting was not preserved")
+			}
+			gotProxyURL, err := transport.Proxy(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotProxyURL.String() != proxyURL.String() || transport.MaxIdleConns != 42 {
+				t.Fatalf("default transport settings were not preserved: %#v", transport)
+			}
+			if transport.TLSClientConfig.InsecureSkipVerify != test.skipVerify || transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+				t.Fatalf("unexpected TLS configuration: %#v", transport.TLSClientConfig)
+			}
+		})
 	}
 	if defaultTransport.TLSClientConfig.InsecureSkipVerify {
 		t.Fatal("default transport was modified")


### PR DESCRIPTION
Non-validating clients now preserve proxy and connection settings from the default HTTP transport while still disabling TLS certificate verification.

Related issue: [juju/juju#20141](https://github.com/juju/juju/issues/20141)

##TEST##

Tested with a Juju 3.6.19 controller using Goose v5.1.4.
Direct access from the controller to Keystone was blocked, while access through the configured HTTP proxy returned HTTP 300.

Before this patch, the provider precheck bypassed the proxy:

```console
$ juju upgrade-controller -c "$CONTROLLER" \
    --dry-run --agent-version=3.6.20

ERROR cannot make API call to provider:
Get "http://<keystone>/": dial tcp <keystone>: connect: connection refused
```

Exit code: `1`

The same controller was then upgraded to an agent built with Goose v5.1.4 plus this patch.
Under the same proxy and firewall configuration, the same command succeeded:

```console
$ juju upgrade-controller -c "$CONTROLLER" \
    --dry-run --agent-version=3.6.20

best version:
    3.6.20
upgrade to this version by running
    juju upgrade-controller
```

Exit code: `0`